### PR TITLE
Fix wrongly ordered configuration file properties

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,14 @@ jobs:
       - run:
           name: Create build files
           command: |
-            cmake -DCMAKE_BUILD_TYPE=Release -B build
+            cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$(which clang) -DCMAKE_CXX_COMPILER=$(which clang++) -B build
       - run:
           name: Build application
           command: |
             cmake --build build
       - persist_to_workspace:
           root: .
-          paths: ['build']
+          paths: [ 'build' ]
   test:
     executor: default
     steps:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,7 +25,7 @@ HeaderFilterRegex: ''
 FormatStyle: none
 
 CheckOptions:
-  - { key: readability-identifier-naming.NamespaceCase,              value: lower_case }
+  - { key: readability-identifier-naming.NamespaceCase,              value: CamelCase }
   - { key: readability-identifier-naming.ClassCase,                  value: CamelCase }
   - { key: readability-identifier-naming.PrivateMemberPrefix,        value: m_ }
   - { key: readability-identifier-naming.StructCase,                 value: CamelCase }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing
 
-You want to contribute to this repo? Nice! And of course: **you are the best!** Here is a guide on how to work with it and what to expect.
+You want to contribute to this repo? Nice! And of course: **you are the best!** Here is a guide on how to work with it
+and what to expect.
 
 **Build status:**
 
@@ -40,7 +41,8 @@ brew install cmake
 
 ### LLVM
 
-The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. Some tools from the LLVM toolchain are used.
+The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. Some tools from the LLVM
+toolchain are used.
 
 * Site: https://llvm.org/
 * Github: https://github.com/llvm/llvm-project
@@ -78,7 +80,8 @@ brew install ninja
 
 ### Litr
 
-This repo uses Litr itself for its tasks. So installing it will make things easier (though, it is optional). To install Litr:
+This repo uses Litr itself for its tasks. So installing it will make things easier (though, it is optional). To install
+Litr:
 
 ```shell
 brew tap krieselreihe/litr
@@ -119,7 +122,10 @@ Run Litr with the following options if needed:
 
 ### Profiling
 
-A debug build will always also produce profiling information. Running the executable directly will generate a `litr-profile.json` file that can be used with any Chromium based browser tracing tool, e.g. [chrome://tracing](chrome://tracing/). Just drag and drop the file into the tracing view. To generate the file run the local build directly:
+A debug build will always also produce profiling information. Running the executable directly will generate
+a `litr-profile.json` file that can be used with any Chromium based browser tracing tool,
+e.g. [chrome://tracing](chrome://tracing/). Just drag and drop the file into the tracing view. To generate the file run
+the local build directly:
 
 ```shell
 ./build/release/src/client/Client
@@ -139,11 +145,13 @@ Build a release version:
 litr build --target=release
 ```
 
-For a release that can be published, and the release process in full, visit the [wiki](https://github.com/krieselreihe/litr/wiki/Release).
+For a release that can be published, and the release process in full, visit
+the [wiki](https://github.com/krieselreihe/litr/wiki/Release).
 
 ## Tests
 
-After [building the application](#build) you can run unit tests for the build output with [ctest](https://cmake.org/cmake/help/latest/manual/ctest.1.html).
+After [building the application](#build) you can run unit tests for the build output
+with [ctest](https://cmake.org/cmake/help/latest/manual/ctest.1.html).
 
 ```shell
 # Run all tests for debugging build
@@ -211,9 +219,11 @@ cmake --build build/release
 
 ## Tests without Litr
 
-After [building the application](#build) you can run unit tests for the build output with [ctest](https://cmake.org/cmake/help/latest/manual/ctest.1.html).
+After [building the application](#build) you can run unit tests for the build output
+with [ctest](https://cmake.org/cmake/help/latest/manual/ctest.1.html).
 
-**Note:** With CMake 3.20 it will be possible to specify the `--test-dir` option for ctest [[source](https://cmake.org/cmake/help/latest/release/3.20.html#ctest)], making test execution easier.
+**Note:** With CMake 3.20 it will be possible to specify the `--test-dir` option for
+ctest [[source](https://cmake.org/cmake/help/latest/release/3.20.html#ctest)], making test execution easier.
 
 ```shell
 # Run all tests for debugging build
@@ -225,7 +235,8 @@ cd build/release/src/tests && ctest && ../../../..
 
 ## Profiling without Litr
 
-There is a profiling build you can generate running cmake with `PROFILE=ON` (build type is up to you, for real world results use "Release"):
+There is a profiling build you can generate running cmake with `PROFILE=ON` (build type is up to you, for real world
+results use "Release"):
 
 ```shell
 # Create config files
@@ -235,7 +246,9 @@ cmake -GNinja -DPROFILE=ON -DCMAKE_BUILD_TYPE=Release --build build/profile
 cmake --build build/profile
 ```
 
-Running the profiler executable will generate a `litr-profile.json` file that can be used with any Chromium based browser tracing tool, e.g. [chrome://tracing](chrome://tracing/). Just drag and drop the file into the tracing view. To generate the file run:
+Running the profiler executable will generate a `litr-profile.json` file that can be used with any Chromium based
+browser tracing tool, e.g. [chrome://tracing](chrome://tracing/). Just drag and drop the file into the tracing view. To
+generate the file run:
 
 ```shell
 ./build/profile/src/client/Client
@@ -245,19 +258,20 @@ Running the profiler executable will generate a `litr-profile.json` file that ca
 
 ### Different compiler
 
-To create builds on a different compiler the variables `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` can be set, specifying the path to the compiler.
+To create builds on a different compiler the variables `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` can be set,
+specifying the path to the compiler.
 
 Example for clang on macOS, creating a debug build:
 
 ```shell
-cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -B build/debug
+cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -B build/debug
 cmake --build build/debug
 ```
 
 Example for gcc on macOS, creating a debug build:
 
 ```shell
-cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -B build/debug
+cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -B build/debug
 cmake --build build/debug
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ git pull
 Build the configuration files with cmake:
 
 ```shell
-cmake -GNinja -DCMAKE_BUILD_TYPE=Debug --build build/debug
+cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -B build/debug
 ```
 
 Build the application:
@@ -240,7 +240,7 @@ results use "Release"):
 
 ```shell
 # Create config files
-cmake -GNinja -DPROFILE=ON -DCMAKE_BUILD_TYPE=Release --build build/profile
+cmake -GNinja -DPROFILE=ON -DCMAKE_BUILD_TYPE=Release -B build/profile
 
 # Build profile runner
 cmake --build build/profile

--- a/cmake/TestSetup.cmake
+++ b/cmake/TestSetup.cmake
@@ -6,10 +6,9 @@ target_link_libraries(Tests PUBLIC doctest)
 
 # Base test setup
 
-add_library(TestBase INTERFACE)
-target_sources(TestBase INTERFACE
+add_library(TestBase STATIC
   ${PROJECT_SOURCE_DIR}/src/tests/Helpers/TOML.cpp
   ${PROJECT_SOURCE_DIR}/src/tests/Helpers/TOML.hpp)
-target_compile_features(TestBase INTERFACE cxx_std_17)
-target_link_libraries(TestBase INTERFACE doctest fmt toml11)
-target_include_directories(TestBase INTERFACE ${PROJECT_SOURCE_DIR}/src/tests)
+target_compile_features(TestBase PRIVATE cxx_std_17)
+target_link_libraries(TestBase PUBLIC doctest fmt toml11 tsl::ordered_map Core)
+target_include_directories(TestBase PUBLIC ${PROJECT_SOURCE_DIR}/src/tests)

--- a/src/client/Client/Application.hpp
+++ b/src/client/Client/Application.hpp
@@ -8,7 +8,7 @@
 
 #include "Core.hpp"
 
-namespace litr {
+namespace Litr {
 
 class Application {
  public:
@@ -22,4 +22,4 @@ class Application {
   ExitStatus m_exit_status{ExitStatus::SUCCESS};
 };
 
-}  // namespace litr
+}  // namespace Litr

--- a/src/client/Client/Client.cpp
+++ b/src/client/Client/Client.cpp
@@ -14,8 +14,8 @@ int main(int argc, char* argv[]) {
   // Incremented argv plus 1 to skip the program name.
   const std::vector<std::string> arguments{argv + 1, argv + argc};
 
-  litr::Application app{};
-  litr::ExitStatus status{app.run(arguments)};
+  Litr::Application app{};
+  Litr::ExitStatus status{app.run(arguments)};
 
   LITR_PROFILE_END_SESSION();
 

--- a/src/client/Client/Hooks/Handler.cpp
+++ b/src/client/Client/Hooks/Handler.cpp
@@ -4,9 +4,9 @@
 
 #include "Handler.hpp"
 
-namespace litr::hook {
+namespace Litr::Hook {
 
-Handler::Handler(const std::shared_ptr<cli::Instruction>& instruction)
+Handler::Handler(const std::shared_ptr<CLI::Instruction>& instruction)
     : m_instruction(instruction) {}
 
 void Handler::add(
@@ -45,4 +45,4 @@ bool Handler::execute() const {
   return false;
 }
 
-}  // namespace litr::hook
+}  // namespace Litr::Hook

--- a/src/client/Client/Hooks/Handler.hpp
+++ b/src/client/Client/Hooks/Handler.hpp
@@ -10,33 +10,33 @@
 
 #include "Core.hpp"
 
-namespace litr::hook {
+namespace Litr::Hook {
 
 class Handler {
-  using HookCallback = std::function<void(const std::shared_ptr<cli::Instruction>& instruction)>;
-  using Code = cli::Instruction::Code;
-  using Value = cli::Instruction::Value;
+  using HookCallback = std::function<void(const std::shared_ptr<CLI::Instruction>& instruction)>;
+  using Code = CLI::Instruction::Code;
+  using Value = CLI::Instruction::Value;
 
   struct Hook {
-    cli::Instruction::Code code;
-    cli::Instruction::Value value;
+    CLI::Instruction::Code code;
+    CLI::Instruction::Value value;
     HookCallback callback;
 
-    Hook(cli::Instruction::Code code, cli::Instruction::Value value, HookCallback callback)
+    Hook(CLI::Instruction::Code code, CLI::Instruction::Value value, HookCallback callback)
         : code(code),
           value(std::move(value)),
           callback(std::move(callback)) {}
   };
 
  public:
-  explicit Handler(const std::shared_ptr<cli::Instruction>& instruction);
+  explicit Handler(const std::shared_ptr<CLI::Instruction>& instruction);
 
   void add(Code code, const std::vector<Value>& values, const HookCallback& callback);
   [[nodiscard]] bool execute() const;
 
  private:
-  const std::shared_ptr<cli::Instruction>& m_instruction;
+  const std::shared_ptr<CLI::Instruction>& m_instruction;
   std::vector<Hook> m_hooks{};
 };
 
-}  // namespace litr::hook
+}  // namespace Litr::Hook

--- a/src/client/Client/Hooks/Help.hpp
+++ b/src/client/Client/Hooks/Help.hpp
@@ -8,45 +8,45 @@
 
 #include "Core.hpp"
 
-namespace litr::hook {
+namespace Litr::Hook {
 
 class Help {
  public:
-  explicit Help(const std::shared_ptr<config::Loader>& config);
+  explicit Help(const std::shared_ptr<Config::Loader>& config);
 
-  void print(const std::shared_ptr<cli::Instruction>& instruction) const;
+  void print(const std::shared_ptr<CLI::Instruction>& instruction) const;
 
  private:
   void print_welcome_message() const;
   void print_usage() const;
   void print_commands() const;
-  void print_command(const std::shared_ptr<config::Command>& command,
+  void print_command(const std::shared_ptr<Config::Command>& command,
       const std::string& parent_name,
       size_t depth = 1) const;
-  void print_example(const std::shared_ptr<config::Command>& command) const;
+  void print_example(const std::shared_ptr<Config::Command>& command) const;
   void print_options() const;
-  void print_parameter_options(const std::shared_ptr<config::Parameter>& param) const;
-  void print_default_parameter_option(const std::shared_ptr<config::Parameter>& param) const;
+  void print_parameter_options(const std::shared_ptr<Config::Parameter>& param) const;
+  void print_default_parameter_option(const std::shared_ptr<Config::Parameter>& param) const;
   void print_with_description(
       const std::string& name, const std::string& description, size_t extra_padding = 0) const;
 
   [[nodiscard]] static std::string get_command_name(
-      const std::shared_ptr<cli::Instruction>& instruction);
+      const std::shared_ptr<CLI::Instruction>& instruction);
   [[nodiscard]] std::string get_command_arguments(const std::string& name) const;
 
   [[nodiscard]] size_t get_command_padding() const;
-  [[nodiscard]] size_t get_command_padding(const config::Query::Commands& commands) const;
+  [[nodiscard]] size_t get_command_padding(const Config::Query::Commands& commands) const;
   [[nodiscard]] size_t get_parameter_padding() const;
 
   [[nodiscard]] static bool sort_parameter_by_required(
-      const std::shared_ptr<config::Parameter>& param1,
-      const std::shared_ptr<config::Parameter>& param2);
+      const std::shared_ptr<Config::Parameter>& param1,
+      const std::shared_ptr<Config::Parameter>& param2);
 
-  const config::Query m_query;
+  const Config::Query m_query;
   const Path m_file_path;
 
   mutable std::string m_command_name{};
   const std::string m_argument_placeholder{"=<option>"};
 };
 
-}  // namespace litr::hook
+}  // namespace Litr::Hook

--- a/src/client/Client/Hooks/Version.cpp
+++ b/src/client/Client/Hooks/Version.cpp
@@ -8,10 +8,10 @@
 
 #include "Core.hpp"
 
-namespace litr::hook {
+namespace Litr::Hook {
 
-void Version::print([[maybe_unused]] const std::shared_ptr<cli::Instruction>& instruction) {
+void Version::print([[maybe_unused]] const std::shared_ptr<CLI::Instruction>& instruction) {
   fmt::print("{}.{}.{}\n", LITR_VERSION_MAJOR, LITR_VERSION_MINOR, LITR_VERSION_PATCH);
 }
 
-}  // namespace litr::hook
+}  // namespace Litr::Hook

--- a/src/client/Client/Hooks/Version.hpp
+++ b/src/client/Client/Hooks/Version.hpp
@@ -8,11 +8,11 @@
 
 #include "Core.hpp"
 
-namespace litr::hook {
+namespace Litr::Hook {
 
 class Version {
  public:
-  static void print(const std::shared_ptr<cli::Instruction>& instruction);
+  static void print(const std::shared_ptr<CLI::Instruction>& instruction);
 };
 
-}  // namespace litr::hook
+}  // namespace Litr::Hook

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,7 +23,8 @@ add_library(${NAME} STATIC
   Core/CLI/Interpreter.cpp Core/CLI/Interpreter.hpp
   Core/Script/Compiler.cpp Core/Script/Compiler.hpp
   Core/Script/Scanner.cpp Core/Script/Scanner.hpp
-  Core/Script/Token.hpp Core/CLI/Variable.hpp)
+  Core/Script/Token.hpp Core/CLI/Variable.hpp
+  Core/Config/FileAdapter.hpp Core/Config/TomlFileAdapter.hpp Core/Config/TomlFileAdapter.cpp)
 
 # Define set of OS specific files to include
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -32,7 +33,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_sources(${NAME} PRIVATE Platform/LinuxEnvironment.cpp)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   target_sources(${NAME} PRIVATE Platform/MacEnvironment.cpp)
-endif()
+endif ()
 
 target_include_directories(${NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(${NAME} PRIVATE cxx_std_17)

--- a/src/core/Core.hpp
+++ b/src/core/Core.hpp
@@ -20,11 +20,13 @@
 // Config -----------------------------
 
 #include "Core/Config/Command.hpp"
+#include "Core/Config/FileAdapter.hpp"
 #include "Core/Config/FileResolver.hpp"
 #include "Core/Config/Loader.hpp"
 #include "Core/Config/Location.hpp"
 #include "Core/Config/Parameter.hpp"
 #include "Core/Config/Query.hpp"
+#include "Core/Config/TomlFileAdapter.hpp"
 
 // CLI --------------------------------
 

--- a/src/core/Core/CLI/Instruction.cpp
+++ b/src/core/Core/CLI/Instruction.cpp
@@ -8,7 +8,7 @@
 
 #include "Core/Debug/Instrumentor.hpp"
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 Instruction::Instruction(std::vector<std::byte> data) : m_byte_code(std::move(data)) {}
 
@@ -47,4 +47,4 @@ Instruction::Value Instruction::read_constant(const std::byte index) const {
   return m_constants[static_cast<size_t>(index)];
 }
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/CLI/Instruction.hpp
+++ b/src/core/Core/CLI/Instruction.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 class Instruction {
  public:
@@ -39,4 +39,4 @@ class Instruction {
   std::vector<Value> m_constants{};
 };
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/CLI/Interpreter.hpp
+++ b/src/core/Core/CLI/Interpreter.hpp
@@ -18,22 +18,22 @@
 #include "Core/Config/Query.hpp"
 #include "Core/Error/Handler.hpp"
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 class Interpreter {
-  using Variables = std::unordered_map<std::string, cli::Variable>;
+  using Variables = std::unordered_map<std::string, CLI::Variable>;
   using Scripts = std::vector<std::string>;
 
  public:
   Interpreter(const std::shared_ptr<Instruction>& instruction,
-      const std::shared_ptr<config::Loader>& config);
+      const std::shared_ptr<Config::Loader>& config);
 
   void execute();
 
  private:
   [[nodiscard]] Instruction::Value read_current_value() const;
   [[nodiscard]] Variables get_scope_variables() const;
-  void define_default_variables(const std::shared_ptr<config::Loader>& config);
+  void define_default_variables(const std::shared_ptr<Config::Loader>& config);
 
   void execute_instruction();
 
@@ -43,29 +43,29 @@ class Interpreter {
   void set_constant();
   void call_instruction();
 
-  void call_command(const std::shared_ptr<config::Command>& command, const std::string& scope = "");
+  void call_command(const std::shared_ptr<Config::Command>& command, const std::string& scope = "");
   void call_child_commands(
-      const std::shared_ptr<config::Command>& command, const std::string& scope);
+      const std::shared_ptr<Config::Command>& command, const std::string& scope);
   void run_scripts(const Scripts& scripts,
       const std::string& command_path,
       const std::string& dir,
       bool print_result);
 
-  [[nodiscard]] Scripts parse_scripts(const std::shared_ptr<config::Command>& command);
+  [[nodiscard]] Scripts parse_scripts(const std::shared_ptr<Config::Command>& command);
   [[nodiscard]] std::string parse_script(
-      const std::string& script, const config::Location& location);
+      const std::string& script, const Config::Location& location);
 
   [[nodiscard]] static enum Variable::Type get_variable_type(
-      const std::shared_ptr<config::Parameter>& param);
+      const std::shared_ptr<Config::Parameter>& param);
 
-  void validate_required_parameters(const std::shared_ptr<config::Command>& command);
+  void validate_required_parameters(const std::shared_ptr<Config::Command>& command);
   [[nodiscard]] bool is_variable_defined(const std::string& name) const;
-  void handle_error(const error::BaseError& error);
+  void handle_error(const Error::BaseError& error);
 
   static void print(const std::string& message);
 
   const std::shared_ptr<Instruction>& m_instruction;
-  const config::Query m_query;
+  const Config::Query m_query;
 
   size_t m_offset{0};
   std::string m_current_variable_name{};
@@ -75,4 +75,4 @@ class Interpreter {
   std::vector<Variables> m_scope{Variables()};
 };
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/CLI/Parser.cpp
+++ b/src/core/Core/CLI/Parser.cpp
@@ -10,7 +10,7 @@
 #include "Core/Error/Handler.hpp"
 #include "Core/Utils.hpp"
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 Parser::Parser(const std::shared_ptr<Instruction>& instruction, const std::string& source)
     : m_source(source),
@@ -171,12 +171,12 @@ void Parser::commands() {
 void Parser::parameters() {
   LITR_PROFILE_FUNCTION();
 
-  emit_definition(utils::trim_left(Scanner::get_token_value(m_previous), '-'));
+  emit_definition(Utils::trim_left(Scanner::get_token_value(m_previous), '-'));
 
   if (peak(TokenType::EQUAL)) {
     advance();
     consume(TokenType::STRING, "Value assignment missing.");
-    emit_constant(utils::trim(Scanner::get_token_value(m_previous), '"'));
+    emit_constant(Utils::trim(Scanner::get_token_value(m_previous), '"'));
   }
 }
 
@@ -239,8 +239,8 @@ void Parser::error_at(Token* token, const std::string& message) {
 
   out_message.append(fmt::format(": {}", message));
 
-  error::Handler::push(
-      error::CLIParserError(out_message, 1, token->column, utils::trim(m_source, ' ')));
+  Error::Handler::push(
+      Error::CLIParserError(out_message, 1, token->column, Utils::trim(m_source, ' ')));
 
   m_has_error = true;
 }
@@ -260,4 +260,4 @@ std::string Parser::get_scope_path() const {
   return value;
 }
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/CLI/Parser.hpp
+++ b/src/core/Core/CLI/Parser.hpp
@@ -12,7 +12,7 @@
 #include "Core/CLI/Scanner.hpp"
 #include "Core/CLI/Token.hpp"
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 class Parser {
  public:
@@ -63,4 +63,4 @@ class Parser {
   bool m_panic_mode{false};
 };
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/CLI/Scanner.cpp
+++ b/src/core/Core/CLI/Scanner.cpp
@@ -6,7 +6,7 @@
 
 #include "Core/Debug/Instrumentor.hpp"
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 Scanner::Scanner(const char* source) : m_start(source), m_current(source) {}
 
@@ -234,4 +234,4 @@ Token Scanner::short_parameter() {
   return make_token(TokenType::SHORT_PARAMETER);
 }
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/CLI/Scanner.hpp
+++ b/src/core/Core/CLI/Scanner.hpp
@@ -8,7 +8,7 @@
 
 #include "Core/CLI/Token.hpp"
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 class Scanner {
  public:
@@ -44,4 +44,4 @@ class Scanner {
   uint32_t m_column{1};
 };
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/CLI/Shell.cpp
+++ b/src/core/Core/CLI/Shell.cpp
@@ -9,7 +9,7 @@
 #include "Core/Debug/Instrumentor.hpp"
 #include "Core/Log.hpp"
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 Shell::Result Shell::exec(const std::string& command, const Path& path) {
   LITR_PROFILE_FUNCTION();
@@ -93,4 +93,4 @@ std::string Shell::create_cd_command(const Path& path) {
   return cmd;
 }
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/CLI/Shell.hpp
+++ b/src/core/Core/CLI/Shell.hpp
@@ -10,7 +10,7 @@
 #include "Core/ExitStatus.hpp"
 #include "Core/FileSystem.hpp"
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 class Shell {
  public:
@@ -33,4 +33,4 @@ class Shell {
   [[nodiscard]] static std::string create_cd_command(const Path& path);
 };
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/CLI/Token.hpp
+++ b/src/core/Core/CLI/Token.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 enum class TokenType {
   COMMA,
@@ -25,4 +25,4 @@ struct Token {
   uint32_t column;
 };
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/CLI/Variable.hpp
+++ b/src/core/Core/CLI/Variable.hpp
@@ -12,6 +12,8 @@
 
 namespace litr::cli {
 
+using namespace std::string_literals;
+
 struct Variable {
   enum class Type { STRING, BOOLEAN };
 
@@ -19,7 +21,7 @@ struct Variable {
   std::string name;
   // Default value should be an empty string as booleans
   // are always handled explicit.
-  std::variant<std::string, bool> value{};
+  std::variant<std::string, bool> value{""s};
 
   Variable(enum Type type, std::string name) : type(type), name(std::move(name)) {}
 
@@ -38,7 +40,7 @@ struct Variable {
       case config::Parameter::Type::STRING:
       case config::Parameter::Type::ARRAY:
         type = Type::STRING;
-        value = "";
+        value = ""s;
         break;
       case config::Parameter::Type::BOOLEAN:
         type = Type::BOOLEAN;

--- a/src/core/Core/CLI/Variable.hpp
+++ b/src/core/Core/CLI/Variable.hpp
@@ -10,7 +10,7 @@
 
 #include "Core/Config/Parameter.hpp"
 
-namespace litr::cli {
+namespace Litr::CLI {
 
 using namespace std::string_literals;
 
@@ -35,14 +35,14 @@ struct Variable {
         name(std::move(name)),
         value(std::move(value)) {}
 
-  explicit Variable(const config::Parameter& parameter) : name(parameter.name) {
+  explicit Variable(const Config::Parameter& parameter) : name(parameter.name) {
     switch (parameter.type) {
-      case config::Parameter::Type::STRING:
-      case config::Parameter::Type::ARRAY:
+      case Config::Parameter::Type::STRING:
+      case Config::Parameter::Type::ARRAY:
         type = Type::STRING;
         value = ""s;
         break;
-      case config::Parameter::Type::BOOLEAN:
+      case Config::Parameter::Type::BOOLEAN:
         type = Type::BOOLEAN;
         value = false;
         break;
@@ -50,4 +50,4 @@ struct Variable {
   }
 };
 
-}  // namespace litr::cli
+}  // namespace Litr::CLI

--- a/src/core/Core/Config/Command.hpp
+++ b/src/core/Core/Config/Command.hpp
@@ -13,7 +13,7 @@
 
 #include "Core/Config/Location.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 struct Command {
   enum class Output { UNCHANGED = 0, SILENT = 1 };
@@ -32,19 +32,19 @@ struct Command {
   explicit Command(std::string name) : name(std::move(name)) {}
 };
 
-}  // namespace litr::config
+}  // namespace Litr::Config
 
 #ifdef DEBUG
 // Enable easy formatting with fmt
 template <>
-struct fmt::formatter<litr::config::Command> {
+struct fmt::formatter<Litr::Config::Command> {
   template <typename ParseContext>
   constexpr auto parse(ParseContext& ctx) {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  auto format(const litr::config::Command& c, FormatContext& ctx) {
+  auto format(const Litr::Config::Command& c, FormatContext& ctx) {
     std::string child_view{};
     if (!c.child_commands.empty()) {
       for (auto&& child : c.child_commands) {

--- a/src/core/Core/Config/CommandBuilder.cpp
+++ b/src/core/Core/Config/CommandBuilder.cpp
@@ -8,7 +8,7 @@
 
 #include "Core/Error/Handler.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 CommandBuilder::CommandBuilder(const TomlFileAdapter::Value& context,
     const TomlFileAdapter::Value& data,
@@ -42,7 +42,7 @@ void CommandBuilder::add_script(const TomlFileAdapter::Value& scripts) {
 
   for (auto&& script : scripts.as_array()) {
     if (!script.is_string()) {
-      error::Handler::push(error::MalformedScriptError(
+      Error::Handler::push(Error::MalformedScriptError(
           "A command script can be either a string or array of strings.",
           m_context.at(m_command->name)));
       // Stop after first error in an array of scripts, to avoid being too verbose.
@@ -66,7 +66,7 @@ void CommandBuilder::add_description() {
       return;
     }
 
-    error::Handler::push(error::MalformedCommandError(
+    Error::Handler::push(Error::MalformedCommandError(
         fmt::format(R"(The "{}" can only be a string.)", name), m_table.at(name)));
   }
 }
@@ -83,7 +83,7 @@ void CommandBuilder::add_example() {
       return;
     }
 
-    error::Handler::push(error::MalformedCommandError(
+    Error::Handler::push(Error::MalformedCommandError(
         fmt::format(R"(The "{}" can only be a string.)", name), m_table.at(name)));
   }
 }
@@ -104,7 +104,7 @@ void CommandBuilder::add_directory(const Path& root) {
     if (directories.is_array()) {
       for (auto&& directory : directories.as_array()) {
         if (!directory.is_string()) {
-          error::Handler::push(error::MalformedCommandError(
+          Error::Handler::push(Error::MalformedCommandError(
               fmt::format(R"(A "{}" can either be a string or array of strings.)", name),
               m_table.at(name)));
           continue;
@@ -115,7 +115,7 @@ void CommandBuilder::add_directory(const Path& root) {
       return;
     }
 
-    error::Handler::push(error::MalformedCommandError(
+    Error::Handler::push(Error::MalformedCommandError(
         fmt::format(R"(A "{}" can either be a string or array of strings.)", name),
         m_table.at(name)));
   }
@@ -141,7 +141,7 @@ void CommandBuilder::add_output() {
       }
     }
 
-    error::Handler::push(error::MalformedCommandError(
+    Error::Handler::push(Error::MalformedCommandError(
         fmt::format(R"(The "{}" can either be "unchanged" or "silent".)", name), m_table.at(name)));
   }
 }
@@ -159,4 +159,4 @@ void CommandBuilder::add_location(const TomlFileAdapter::Value& context) {
       context.location().line(), context.location().column(), context.location().line_str());
 }
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/CommandBuilder.cpp
+++ b/src/core/Core/Config/CommandBuilder.cpp
@@ -10,7 +10,7 @@
 
 namespace litr::config {
 
-CommandBuilder::CommandBuilder(const TomlFileAdapter::Table& context,
+CommandBuilder::CommandBuilder(const TomlFileAdapter::Value& context,
     const TomlFileAdapter::Value& data,
     const std::string& name)
     : m_context(context),
@@ -59,7 +59,7 @@ void CommandBuilder::add_description() {
   const std::string name{"description"};
 
   if (m_table.contains(name)) {
-    const TomlFileAdapter::Value& description{m_file.find_value(m_table, name)};
+    const TomlFileAdapter::Value& description{m_file.find(m_table, name)};
 
     if (description.is_string()) {
       m_command->description = description.as_string();
@@ -77,7 +77,7 @@ void CommandBuilder::add_example() {
   const std::string name{"example"};
 
   if (m_table.contains(name)) {
-    const TomlFileAdapter::Value& example{m_file.find_value(m_table, name)};
+    const TomlFileAdapter::Value& example{m_file.find(m_table, name)};
     if (example.is_string()) {
       m_command->example = example.as_string();
       return;
@@ -94,7 +94,7 @@ void CommandBuilder::add_directory(const Path& root) {
   const std::string name{"dir"};
 
   if (m_table.contains(name)) {
-    const TomlFileAdapter::Value& directories{m_file.find_value(m_table, name)};
+    const TomlFileAdapter::Value& directories{m_file.find(m_table, name)};
 
     if (directories.is_string()) {
       m_command->directory.emplace_back(root.append(directories.as_string()));
@@ -127,7 +127,7 @@ void CommandBuilder::add_output() {
   const std::string name{"output"};
 
   if (m_table.contains(name)) {
-    const TomlFileAdapter::Value& output{m_file.find_value(m_table, name)};
+    const TomlFileAdapter::Value& output{m_file.find(m_table, name)};
 
     if (output.is_string()) {
       if (output.as_string() == "silent") {

--- a/src/core/Core/Config/CommandBuilder.hpp
+++ b/src/core/Core/Config/CommandBuilder.hpp
@@ -18,7 +18,7 @@ namespace litr::config {
 
 class CommandBuilder {
  public:
-  CommandBuilder(const TomlFileAdapter::Table& context,
+  CommandBuilder(const TomlFileAdapter::Value& context,
       const TomlFileAdapter::Value& data,
       const std::string& name);
 
@@ -40,7 +40,7 @@ class CommandBuilder {
  private:
   void add_location(const TomlFileAdapter::Value& context);
 
-  const TomlFileAdapter::Table& m_context;
+  const TomlFileAdapter::Value& m_context;
   const TomlFileAdapter::Value& m_table;
   const std::shared_ptr<Command> m_command;
   const TomlFileAdapter m_file{};

--- a/src/core/Core/Config/CommandBuilder.hpp
+++ b/src/core/Core/Config/CommandBuilder.hpp
@@ -4,24 +4,28 @@
 
 #pragma once
 
+#include <tsl/ordered_map.h>
+
 #include <memory>
 #include <string>
-#include <toml.hpp>
 #include <vector>
 
 #include "Core/Config/Command.hpp"
+#include "Core/Config/TomlFileAdapter.hpp"
 #include "Core/FileSystem.hpp"
 
 namespace litr::config {
 
 class CommandBuilder {
  public:
-  CommandBuilder(const toml::table& file, const toml::value& data, const std::string& name);
+  CommandBuilder(const TomlFileAdapter::Table& context,
+      const TomlFileAdapter::Value& data,
+      const std::string& name);
 
   void add_script_line(const std::string& line);
-  void add_script_line(const std::string& line, const toml::value& context);
+  void add_script_line(const std::string& line, const TomlFileAdapter::Value& context);
   void add_script(const std::vector<std::string>& scripts);
-  void add_script(const toml::value& scripts);
+  void add_script(const TomlFileAdapter::Value& scripts);
 
   void add_description();
   void add_example();
@@ -34,11 +38,12 @@ class CommandBuilder {
   }
 
  private:
-  void add_location(const toml::value& context);
+  void add_location(const TomlFileAdapter::Value& context);
 
-  const toml::table& m_file;
-  const toml::value& m_table;
+  const TomlFileAdapter::Table& m_context;
+  const TomlFileAdapter::Value& m_table;
   const std::shared_ptr<Command> m_command;
+  const TomlFileAdapter m_file{};
 };
 
 }  // namespace litr::config

--- a/src/core/Core/Config/CommandBuilder.hpp
+++ b/src/core/Core/Config/CommandBuilder.hpp
@@ -14,7 +14,7 @@
 #include "Core/Config/TomlFileAdapter.hpp"
 #include "Core/FileSystem.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 class CommandBuilder {
  public:
@@ -46,4 +46,4 @@ class CommandBuilder {
   const TomlFileAdapter m_file{};
 };
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/FileAdapter.hpp
+++ b/src/core/Core/Config/FileAdapter.hpp
@@ -10,7 +10,7 @@
 
 #include "Core/FileSystem.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 template <typename T>
 class FileAdapter {
@@ -25,4 +25,4 @@ class FileAdapter {
   virtual const Value& find(const Value&, const std::string& key) const = 0;
 };
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/FileAdapter.hpp
+++ b/src/core/Core/Config/FileAdapter.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 Martin Helmut Fieber <info@martin-fieber.se>
+ */
+
+#pragma once
+
+#include <tsl/ordered_map.h>
+
+#include <string>
+
+#include "Core/FileSystem.hpp"
+
+namespace litr::config {
+
+template <typename T>
+class FileAdapter {
+ public:
+  using Value = T;
+  using Table = tsl::ordered_map<std::string, Value>;
+
+  virtual ~FileAdapter() = default;
+
+  virtual Value parse(const Path& file_path) const = 0;
+
+  virtual const Value& find_value(const Value&, const std::string& key) const = 0;
+  virtual const Table& find_table(const Value&, const std::string& key) const = 0;
+};
+
+}  // namespace litr::config

--- a/src/core/Core/Config/FileAdapter.hpp
+++ b/src/core/Core/Config/FileAdapter.hpp
@@ -22,8 +22,7 @@ class FileAdapter {
 
   virtual Value parse(const Path& file_path) const = 0;
 
-  virtual const Value& find_value(const Value&, const std::string& key) const = 0;
-  virtual const Table& find_table(const Value&, const std::string& key) const = 0;
+  virtual const Value& find(const Value&, const std::string& key) const = 0;
 };
 
 }  // namespace litr::config

--- a/src/core/Core/Config/FileResolver.cpp
+++ b/src/core/Core/Config/FileResolver.cpp
@@ -8,7 +8,7 @@
 #include "Core/Environment.hpp"
 #include "Core/Log.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 FileResolver::FileResolver(const std::string& cwd) : FileResolver(Path(cwd)) {}
 
@@ -78,4 +78,4 @@ void FileResolver::find_file(const Path& cwd) {
   }
 }
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/FileResolver.hpp
+++ b/src/core/Core/Config/FileResolver.hpp
@@ -8,7 +8,7 @@
 
 #include "Core/FileSystem.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 class FileResolver {
  public:
@@ -36,4 +36,4 @@ class FileResolver {
   void find_file(const Path& cwd);
 };
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/Loader.cpp
+++ b/src/core/Core/Config/Loader.cpp
@@ -14,13 +14,13 @@
 #include "Core/Log.hpp"
 #include "Core/Utils.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 Loader::Loader(Path file_path) : m_file_path(std::move(file_path)) {
   LITR_PROFILE_FUNCTION();
 
   TomlFileAdapter::Value config{m_file.parse(m_file_path)};
-  if (error::Handler::has_errors()) {
+  if (Error::Handler::has_errors()) {
     return;
   }
 
@@ -57,8 +57,8 @@ std::shared_ptr<Command> Loader::create_command(const TomlFileAdapter::Value& co
 
   // From here on it needs to be a table to be valid.
   if (!definition.is_table()) {
-    error::Handler::push(
-        error::MalformedCommandError("A command can be a string or table.", commands.at(name)));
+    Error::Handler::push(
+        Error::MalformedCommandError("A command can be a string or table.", commands.at(name)));
     return builder.get_result();
   }
 
@@ -69,7 +69,7 @@ std::shared_ptr<Command> Loader::create_command(const TomlFileAdapter::Value& co
   }
 
   while (!properties.empty()) {
-    LITR_PROFILE_SCOPE("Config::Loader::create_command::CollectCommandProperties(while)");
+    LITR_PROFILE_SCOPE("Config::Loader::create_command > collect_command_properties(while)");
     const std::string property{properties.front()};
 
     if (property == "script") {
@@ -80,7 +80,7 @@ std::shared_ptr<Command> Loader::create_command(const TomlFileAdapter::Value& co
       } else if (scripts.is_array()) {
         builder.add_script(scripts);
       } else {
-        error::Handler::push(error::MalformedScriptError(
+        Error::Handler::push(Error::MalformedScriptError(
             "A command script can be either a string or array of strings.",
             definition.at(property)));
       }
@@ -116,7 +116,7 @@ std::shared_ptr<Command> Loader::create_command(const TomlFileAdapter::Value& co
     // Collect properties that cannot directly be resolved.
     const TomlFileAdapter::Value& value{m_file.find(definition, property)};
     if (!value.is_table()) {
-      error::Handler::push(error::UnknownCommandPropertyError(
+      Error::Handler::push(Error::UnknownCommandPropertyError(
           fmt::format(
               R"(The command property "{}" does not exist. Please refer to the docs.)", property),
           definition.at(property)));
@@ -153,7 +153,7 @@ void Loader::collect_params(const TomlFileAdapter::Value& params) {
     ParameterBuilder builder{params, definition, name};
 
     if (ParameterBuilder::is_reserved_name(name)) {
-      error::Handler::push(error::ReservedParamError(
+      Error::Handler::push(Error::ReservedParamError(
           fmt::format(R"(The parameter name "{}" is reserved by Litr.)", name), params.at(name)));
       continue;
     }
@@ -167,7 +167,7 @@ void Loader::collect_params(const TomlFileAdapter::Value& params) {
 
     // From here on it needs to be a table to be valid.
     if (!definition.is_table()) {
-      error::Handler::push(error::MalformedParamError(
+      Error::Handler::push(Error::MalformedParamError(
           "A parameter needs to be a string or table.", params.at(name)));
       continue;
     }
@@ -181,4 +181,4 @@ void Loader::collect_params(const TomlFileAdapter::Value& params) {
   }
 }
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/Loader.hpp
+++ b/src/core/Core/Config/Loader.hpp
@@ -15,7 +15,7 @@
 #include "Core/Config/TomlFileAdapter.hpp"
 #include "Core/FileSystem.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 // @todo: "Loader" is a horrible name. I thought about "File", but this feels rather
 //  generic and only works in context of the namespace "config". I have no clue how
@@ -50,4 +50,4 @@ class Loader {
   Parameters m_parameters{};
 };
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/Loader.hpp
+++ b/src/core/Core/Config/Loader.hpp
@@ -38,11 +38,11 @@ class Loader {
   }
 
  private:
-  std::shared_ptr<Command> create_command(const TomlFileAdapter::Table& commands,
+  std::shared_ptr<Command> create_command(const TomlFileAdapter::Value& commands,
       const TomlFileAdapter::Value& definition,
       const std::string& name);
-  void collect_commands(const TomlFileAdapter::Table& commands);
-  void collect_params(const TomlFileAdapter::Table& params);
+  void collect_commands(const TomlFileAdapter::Value& commands);
+  void collect_params(const TomlFileAdapter::Value& params);
 
   const Path m_file_path;
   const TomlFileAdapter m_file{};

--- a/src/core/Core/Config/Loader.hpp
+++ b/src/core/Core/Config/Loader.hpp
@@ -7,16 +7,19 @@
 #include <deque>
 #include <memory>
 #include <string>
-#include <toml.hpp>
 #include <utility>
 #include <vector>
 
 #include "Core/Config/Command.hpp"
 #include "Core/Config/Parameter.hpp"
+#include "Core/Config/TomlFileAdapter.hpp"
 #include "Core/FileSystem.hpp"
 
 namespace litr::config {
 
+// @todo: "Loader" is a horrible name. I thought about "File", but this feels rather
+//  generic and only works in context of the namespace "config". I have no clue how
+//  to name this better thought.
 class Loader {
  public:
   using Commands = std::vector<std::shared_ptr<Command>>;
@@ -35,12 +38,14 @@ class Loader {
   }
 
  private:
-  std::shared_ptr<Command> create_command(
-      const toml::table& commands, const toml::value& definition, const std::string& name);
-  void collect_commands(const toml::table& commands);
-  void collect_params(const toml::table& params);
+  std::shared_ptr<Command> create_command(const TomlFileAdapter::Table& commands,
+      const TomlFileAdapter::Value& definition,
+      const std::string& name);
+  void collect_commands(const TomlFileAdapter::Table& commands);
+  void collect_params(const TomlFileAdapter::Table& params);
 
   const Path m_file_path;
+  const TomlFileAdapter m_file{};
   Commands m_commands{};
   Parameters m_parameters{};
 };

--- a/src/core/Core/Config/Location.hpp
+++ b/src/core/Core/Config/Location.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <utility>
 
-namespace litr::config {
+namespace Litr::Config {
 
 struct Location {
   uint32_t line{};
@@ -21,4 +21,4 @@ struct Location {
         line_str(std::move(lineStr)) {}
 };
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/Parameter.hpp
+++ b/src/core/Core/Config/Parameter.hpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-namespace litr::config {
+namespace Litr::Config {
 
 struct Parameter {
   enum class Type { STRING = 0, BOOLEAN = 1, ARRAY = 2 };
@@ -27,19 +27,19 @@ struct Parameter {
   explicit Parameter(std::string name) : name(std::move(name)) {}
 };
 
-}  // namespace litr::config
+}  // namespace Litr::Config
 
 #ifdef DEBUG
 // Enable easy formatting with fmt
 template <>
-struct fmt::formatter<litr::config::Parameter> {
+struct fmt::formatter<Litr::Config::Parameter> {
   template <typename ParseContext>
   constexpr auto parse(ParseContext& ctx) {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  auto format(const litr::config::Parameter& p, FormatContext& ctx) {
+  auto format(const Litr::Config::Parameter& p, FormatContext& ctx) {
     if (!p.description.empty()) {
       return format_to(ctx.out(), "Param: {} - {}", p.name, p.description);
     }

--- a/src/core/Core/Config/ParameterBuilder.cpp
+++ b/src/core/Core/Config/ParameterBuilder.cpp
@@ -10,7 +10,7 @@
 
 namespace litr::config {
 
-ParameterBuilder::ParameterBuilder(const TomlFileAdapter::Table& context,
+ParameterBuilder::ParameterBuilder(const TomlFileAdapter::Value& context,
     const TomlFileAdapter::Value& data,
     const std::string& name)
     : m_context(context),
@@ -30,7 +30,7 @@ void ParameterBuilder::add_description() {
     return;
   }
 
-  const TomlFileAdapter::Value& description{m_file.find_value(m_table, name)};
+  const TomlFileAdapter::Value& description{m_file.find(m_table, name)};
 
   if (!description.is_string()) {
     error::Handler::push(error::MalformedParamError(
@@ -57,7 +57,7 @@ void ParameterBuilder::add_shortcut(const std::vector<std::shared_ptr<Parameter>
   const std::string name{"shortcut"};
 
   if (m_table.contains(name)) {
-    const TomlFileAdapter::Value& shortcut{m_file.find_value(m_table, name)};
+    const TomlFileAdapter::Value& shortcut{m_file.find(m_table, name)};
 
     if (shortcut.is_string()) {
       const std::string shortcut_str{shortcut.as_string()};
@@ -95,7 +95,7 @@ void ParameterBuilder::add_type() {
   const std::string name{"type"};
 
   if (m_table.contains(name)) {
-    const TomlFileAdapter::Value& type{m_file.find_value(m_table, name)};
+    const TomlFileAdapter::Value& type{m_file.find(m_table, name)};
 
     if (type.is_string()) {
       if (type.as_string() == "string") {
@@ -141,7 +141,7 @@ void ParameterBuilder::add_default() {
   const std::string name{"default"};
 
   if (m_table.contains(name)) {
-    const TomlFileAdapter::Value& def{m_file.find_value(m_table, name)};
+    const TomlFileAdapter::Value& def{m_file.find(m_table, name)};
 
     if (def.is_string()) {
       const std::string default_value{def.as_string()};

--- a/src/core/Core/Config/ParameterBuilder.cpp
+++ b/src/core/Core/Config/ParameterBuilder.cpp
@@ -8,7 +8,7 @@
 #include "Core/Error/Handler.hpp"
 #include "Core/Log.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 ParameterBuilder::ParameterBuilder(const TomlFileAdapter::Value& context,
     const TomlFileAdapter::Value& data,
@@ -25,7 +25,7 @@ void ParameterBuilder::add_description() {
   const std::string name{"description"};
 
   if (!m_table.contains(name)) {
-    error::Handler::push(error::MalformedParamError(
+    Error::Handler::push(Error::MalformedParamError(
         R"(You're missing the "description" field.)", m_context.at(m_parameter->name)));
     return;
   }
@@ -33,7 +33,7 @@ void ParameterBuilder::add_description() {
   const TomlFileAdapter::Value& description{m_file.find(m_table, name)};
 
   if (!description.is_string()) {
-    error::Handler::push(error::MalformedParamError(
+    Error::Handler::push(Error::MalformedParamError(
         fmt::format(R"(The "{}" can only be a string.)", name), m_table.at(name)));
     return;
   }
@@ -63,7 +63,7 @@ void ParameterBuilder::add_shortcut(const std::vector<std::shared_ptr<Parameter>
       const std::string shortcut_str{shortcut.as_string()};
 
       if (is_reserved_name(shortcut_str)) {
-        error::Handler::push(error::ReservedParamError(
+        Error::Handler::push(Error::ReservedParamError(
             fmt::format(R"(The shortcut name "{}" is reserved by Litr.)", shortcut_str),
             m_table.at(name)));
         return;
@@ -71,7 +71,7 @@ void ParameterBuilder::add_shortcut(const std::vector<std::shared_ptr<Parameter>
 
       for (auto&& param : params) {
         if (param->shortcut == shortcut_str) {
-          error::Handler::push(error::ValueAlreadyInUseError(
+          Error::Handler::push(Error::ValueAlreadyInUseError(
               fmt::format(R"(The shortcut name "{}" is already used for parameter "{}".)",
                   shortcut_str,
                   param->name),
@@ -84,7 +84,7 @@ void ParameterBuilder::add_shortcut(const std::vector<std::shared_ptr<Parameter>
       return;
     }
 
-    error::Handler::push(error::MalformedParamError(
+    Error::Handler::push(Error::MalformedParamError(
         fmt::format(R"(A "{}" can only be a string.)", name), m_table.at(name)));
   }
 }
@@ -103,7 +103,7 @@ void ParameterBuilder::add_type() {
       } else if (type.as_string() == "boolean") {
         m_parameter->type = Parameter::Type::BOOLEAN;
       } else {
-        error::Handler::push(error::UnknownParamValueError(
+        Error::Handler::push(Error::UnknownParamValueError(
             fmt::format(
                 R"(The "{}" option as string can only be "string" or "boolean". Provided value "{}" is not known.)",
                 name,
@@ -121,7 +121,7 @@ void ParameterBuilder::add_type() {
         if (option.is_string()) {
           m_parameter->type_arguments.emplace_back(option.as_string());
         } else {
-          error::Handler::push(error::MalformedParamError(
+          Error::Handler::push(Error::MalformedParamError(
               fmt::format(R"(The options provided in "{}" are not all strings.)", name),
               m_table.at(name)));
         }
@@ -129,7 +129,7 @@ void ParameterBuilder::add_type() {
       return;
     }
 
-    error::Handler::push(error::MalformedParamError(
+    Error::Handler::push(Error::MalformedParamError(
         fmt::format(R"(A "{}" can only be "string" or an array of options as strings.)", name),
         m_table.at(name)));
   }
@@ -150,7 +150,7 @@ void ParameterBuilder::add_default() {
       if (m_parameter->type == Parameter::Type::ARRAY) {
         const std::vector<std::string>& args{m_parameter->type_arguments};
         if (std::find(args.begin(), args.end(), default_value) == args.end()) {
-          error::Handler::push(error::MalformedParamError(
+          Error::Handler::push(Error::MalformedParamError(
               fmt::format(
                   R"(Cannot find default value "{}" inside "type" list defined in line {}.)",
                   default_value,
@@ -164,7 +164,7 @@ void ParameterBuilder::add_default() {
       return;
     }
 
-    error::Handler::push(error::MalformedParamError(
+    Error::Handler::push(Error::MalformedParamError(
         fmt::format(R"(The field "{}" needs to be a string.)", name), m_table.at(name)));
   }
 }
@@ -186,4 +186,4 @@ bool ParameterBuilder::is_reserved_name(const std::string& name) {
   return std::find(reserved.begin(), reserved.end(), name) != reserved.end();
 }
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/ParameterBuilder.cpp
+++ b/src/core/Core/Config/ParameterBuilder.cpp
@@ -10,9 +10,10 @@
 
 namespace litr::config {
 
-ParameterBuilder::ParameterBuilder(
-    const toml::table& file, const toml::value& data, const std::string& name)
-    : m_file(file),
+ParameterBuilder::ParameterBuilder(const TomlFileAdapter::Table& context,
+    const TomlFileAdapter::Value& data,
+    const std::string& name)
+    : m_context(context),
       m_table(data),
       m_parameter(std::make_shared<Parameter>(name)) {
   LITR_CORE_TRACE("Creating {}", *m_parameter);
@@ -25,11 +26,11 @@ void ParameterBuilder::add_description() {
 
   if (!m_table.contains(name)) {
     error::Handler::push(error::MalformedParamError(
-        R"(You're missing the "description" field.)", m_file.at(m_parameter->name)));
+        R"(You're missing the "description" field.)", m_context.at(m_parameter->name)));
     return;
   }
 
-  const toml::value& description{toml::find(m_table, name)};
+  const TomlFileAdapter::Value& description{m_file.find_value(m_table, name)};
 
   if (!description.is_string()) {
     error::Handler::push(error::MalformedParamError(
@@ -56,7 +57,7 @@ void ParameterBuilder::add_shortcut(const std::vector<std::shared_ptr<Parameter>
   const std::string name{"shortcut"};
 
   if (m_table.contains(name)) {
-    const toml::value& shortcut{toml::find(m_table, name)};
+    const TomlFileAdapter::Value& shortcut{m_file.find_value(m_table, name)};
 
     if (shortcut.is_string()) {
       const std::string shortcut_str{shortcut.as_string()};
@@ -94,7 +95,7 @@ void ParameterBuilder::add_type() {
   const std::string name{"type"};
 
   if (m_table.contains(name)) {
-    const toml::value& type{toml::find(m_table, name)};
+    const TomlFileAdapter::Value& type{m_file.find_value(m_table, name)};
 
     if (type.is_string()) {
       if (type.as_string() == "string") {
@@ -140,7 +141,7 @@ void ParameterBuilder::add_default() {
   const std::string name{"default"};
 
   if (m_table.contains(name)) {
-    const toml::value& def{toml::find(m_table, name)};
+    const TomlFileAdapter::Value& def{m_file.find_value(m_table, name)};
 
     if (def.is_string()) {
       const std::string default_value{def.as_string()};

--- a/src/core/Core/Config/ParameterBuilder.hpp
+++ b/src/core/Core/Config/ParameterBuilder.hpp
@@ -15,7 +15,7 @@ namespace litr::config {
 
 class ParameterBuilder {
  public:
-  ParameterBuilder(const TomlFileAdapter::Table& context,
+  ParameterBuilder(const TomlFileAdapter::Value& context,
       const TomlFileAdapter::Value& data,
       const std::string& name);
 
@@ -33,7 +33,7 @@ class ParameterBuilder {
   [[nodiscard]] static bool is_reserved_name(const std::string& name);
 
  private:
-  const TomlFileAdapter::Table& m_context;
+  const TomlFileAdapter::Value& m_context;
   const TomlFileAdapter::Value& m_table;
   const std::shared_ptr<Parameter> m_parameter;
   const TomlFileAdapter m_file{};

--- a/src/core/Core/Config/ParameterBuilder.hpp
+++ b/src/core/Core/Config/ParameterBuilder.hpp
@@ -11,7 +11,7 @@
 #include "Core/Config/Parameter.hpp"
 #include "Core/Config/TomlFileAdapter.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 class ParameterBuilder {
  public:
@@ -39,4 +39,4 @@ class ParameterBuilder {
   const TomlFileAdapter m_file{};
 };
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/ParameterBuilder.hpp
+++ b/src/core/Core/Config/ParameterBuilder.hpp
@@ -6,16 +6,18 @@
 
 #include <memory>
 #include <string>
-#include <toml.hpp>
 #include <vector>
 
 #include "Core/Config/Parameter.hpp"
+#include "Core/Config/TomlFileAdapter.hpp"
 
 namespace litr::config {
 
 class ParameterBuilder {
  public:
-  ParameterBuilder(const toml::table& file, const toml::value& data, const std::string& name);
+  ParameterBuilder(const TomlFileAdapter::Table& context,
+      const TomlFileAdapter::Value& data,
+      const std::string& name);
 
   void add_description();
   void add_description(const std::string& description);
@@ -31,9 +33,10 @@ class ParameterBuilder {
   [[nodiscard]] static bool is_reserved_name(const std::string& name);
 
  private:
-  const toml::table& m_file;
-  const toml::value& m_table;
+  const TomlFileAdapter::Table& m_context;
+  const TomlFileAdapter::Value& m_table;
   const std::shared_ptr<Parameter> m_parameter;
+  const TomlFileAdapter m_file{};
 };
 
 }  // namespace litr::config

--- a/src/core/Core/Config/Query.cpp
+++ b/src/core/Core/Config/Query.cpp
@@ -10,7 +10,7 @@
 #include "Core/Script/Compiler.hpp"
 #include "Core/Utils.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 Query::Query(const std::shared_ptr<Loader>& config) : m_config(config) {}
 
@@ -74,7 +74,7 @@ Query::Parameters Query::get_parameters(const std::string& command_name) const {
     names.insert(names.end(), child_names.begin(), child_names.end());
   }
 
-  utils::deduplicate(names);
+  Utils::deduplicate(names);
 
   if (!names.empty()) {
     for (auto&& name : names) {
@@ -89,7 +89,7 @@ Query::Parts Query::split_command_query(const std::string& query) {
   LITR_PROFILE_FUNCTION();
 
   Parts parts{};
-  utils::split_into(query, '.', parts);
+  Utils::split_into(query, '.', parts);
   return parts;
 }
 
@@ -143,7 +143,7 @@ Query::Variables Query::get_parameters_as_variables() const {
   Variables variables{};
 
   for (auto&& param : params) {
-    variables.insert_or_assign(param->name, cli::Variable(*param));
+    variables.insert_or_assign(param->name, CLI::Variable(*param));
   }
 
   return variables;
@@ -158,14 +158,14 @@ std::vector<std::string> Query::get_used_parameter_names(
 
   for (auto&& script : command->script) {
     const Variables variables{get_parameters_as_variables()};
-    const script::Compiler compiler{script, command->Locations[index++], variables};
+    const Script::Compiler compiler{script, command->Locations[index++], variables};
     const std::vector<std::string> used_names{compiler.get_used_variables()};
     names.insert(names.end(), used_names.begin(), used_names.end());
   }
 
-  utils::deduplicate(names);
+  Utils::deduplicate(names);
 
   return names;
 }
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/Query.hpp
+++ b/src/core/Core/Config/Query.hpp
@@ -13,11 +13,11 @@
 #include "Core/CLI/Variable.hpp"
 #include "Core/Config/Loader.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 class Query {
   using Parts = std::deque<std::string>;
-  using Variables = std::unordered_map<std::string, cli::Variable>;
+  using Variables = std::unordered_map<std::string, CLI::Variable>;
 
  public:
   using Commands = std::vector<std::shared_ptr<Command>>;
@@ -47,4 +47,4 @@ class Query {
   const std::shared_ptr<Loader>& m_config;
 };
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/TomlFileAdapter.cpp
+++ b/src/core/Core/Config/TomlFileAdapter.cpp
@@ -7,7 +7,7 @@
 #include "Core/Debug/Instrumentor.hpp"
 #include "Core/Error/Handler.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 TomlFileAdapter::Value TomlFileAdapter::parse(const Path& file_path) const {
   LITR_PROFILE_FUNCTION();
@@ -17,13 +17,13 @@ TomlFileAdapter::Value TomlFileAdapter::parse(const Path& file_path) const {
   try {
     config = toml::parse<toml::discard_comments, tsl::ordered_map>(file_path.to_string());
   } catch (const toml::syntax_error& err) {
-    error::Handler::push(
-        error::MalformedFileError("There is a syntax error inside the configuration file.", err));
+    Error::Handler::push(
+        Error::MalformedFileError("There is a syntax error inside the configuration file.", err));
     return config;
   }
 
   if (!config.is_table()) {
-    error::Handler::push(error::MalformedFileError("Configuration is not a TOML table."));
+    Error::Handler::push(Error::MalformedFileError("Configuration is not a TOML table."));
   }
 
   return config;
@@ -36,4 +36,4 @@ const TomlFileAdapter::Value& TomlFileAdapter::find(
   return toml::find(value, key);
 }
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Config/TomlFileAdapter.cpp
+++ b/src/core/Core/Config/TomlFileAdapter.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Martin Helmut Fieber <info@martin-fieber.se>
+ */
+
+#include "TomlFileAdapter.hpp"
+
+#include "Core/Debug/Instrumentor.hpp"
+#include "Core/Error/Handler.hpp"
+
+namespace litr::config {
+
+TomlFileAdapter::Value TomlFileAdapter::parse(const Path& file_path) const {
+  LITR_PROFILE_FUNCTION();
+
+  TomlFileAdapter::Value config{};
+
+  try {
+    config = toml::parse<toml::discard_comments, tsl::ordered_map>(file_path.to_string());
+  } catch (const toml::syntax_error& err) {
+    error::Handler::push(
+        error::MalformedFileError("There is a syntax error inside the configuration file.", err));
+    return config;
+  }
+
+  if (!config.is_table()) {
+    error::Handler::push(error::MalformedFileError("Configuration is not a TOML table."));
+  }
+
+  return config;
+}
+
+const TomlFileAdapter::Value& TomlFileAdapter::find_value(
+    const TomlFileAdapter::Value& value, const std::string& key) const {
+  LITR_PROFILE_FUNCTION();
+
+  return toml::find(value, key);
+}
+
+const TomlFileAdapter::Table& TomlFileAdapter::find_table(
+    const TomlFileAdapter::Value& value, const std::string& key) const {
+  LITR_PROFILE_FUNCTION();
+
+  return toml::find<TomlFileAdapter::Table, toml::discard_comments, tsl::ordered_map>(value, key);
+}
+
+}  // namespace litr::config

--- a/src/core/Core/Config/TomlFileAdapter.cpp
+++ b/src/core/Core/Config/TomlFileAdapter.cpp
@@ -29,18 +29,11 @@ TomlFileAdapter::Value TomlFileAdapter::parse(const Path& file_path) const {
   return config;
 }
 
-const TomlFileAdapter::Value& TomlFileAdapter::find_value(
+const TomlFileAdapter::Value& TomlFileAdapter::find(
     const TomlFileAdapter::Value& value, const std::string& key) const {
   LITR_PROFILE_FUNCTION();
 
   return toml::find(value, key);
-}
-
-const TomlFileAdapter::Table& TomlFileAdapter::find_table(
-    const TomlFileAdapter::Value& value, const std::string& key) const {
-  LITR_PROFILE_FUNCTION();
-
-  return toml::find<TomlFileAdapter::Table, toml::discard_comments, tsl::ordered_map>(value, key);
 }
 
 }  // namespace litr::config

--- a/src/core/Core/Config/TomlFileAdapter.hpp
+++ b/src/core/Core/Config/TomlFileAdapter.hpp
@@ -20,8 +20,7 @@ class TomlFileAdapter : public FileAdapter<BasicTomlValue> {
 
   [[nodiscard]] Value parse(const Path& file_path) const override;
 
-  [[nodiscard]] const Value& find_value(const Value& value, const std::string& key) const override;
-  [[nodiscard]] const Table& find_table(const Value& value, const std::string& key) const override;
+  [[nodiscard]] const Value& find(const Value& value, const std::string& key) const override;
 };
 
 }  // namespace litr::config

--- a/src/core/Core/Config/TomlFileAdapter.hpp
+++ b/src/core/Core/Config/TomlFileAdapter.hpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Martin Helmut Fieber <info@martin-fieber.se>
+ */
+
+#pragma once
+
+#include <tsl/ordered_map.h>
+
+#include <toml.hpp>
+
+#include "Core/Config/FileAdapter.hpp"
+
+namespace litr::config {
+
+using BasicTomlValue = toml::basic_value<toml::discard_comments, tsl::ordered_map>;
+
+class TomlFileAdapter : public FileAdapter<BasicTomlValue> {
+ public:
+  using Exception = toml::exception;
+
+  [[nodiscard]] Value parse(const Path& file_path) const override;
+
+  [[nodiscard]] const Value& find_value(const Value& value, const std::string& key) const override;
+  [[nodiscard]] const Table& find_table(const Value& value, const std::string& key) const override;
+};
+
+}  // namespace litr::config

--- a/src/core/Core/Config/TomlFileAdapter.hpp
+++ b/src/core/Core/Config/TomlFileAdapter.hpp
@@ -10,7 +10,7 @@
 
 #include "Core/Config/FileAdapter.hpp"
 
-namespace litr::config {
+namespace Litr::Config {
 
 using BasicTomlValue = toml::basic_value<toml::discard_comments, tsl::ordered_map>;
 
@@ -23,4 +23,4 @@ class TomlFileAdapter : public FileAdapter<BasicTomlValue> {
   [[nodiscard]] const Value& find(const Value& value, const std::string& key) const override;
 };
 
-}  // namespace litr::config
+}  // namespace Litr::Config

--- a/src/core/Core/Debug/Disassembler.cpp
+++ b/src/core/Core/Debug/Disassembler.cpp
@@ -6,7 +6,7 @@
 
 #include <fmt/format.h>
 
-namespace litr::debug {
+namespace Litr::Debug {
 
 /** @private */
 static size_t simple_instruction(const std::string& name, const size_t offset) {
@@ -16,31 +16,31 @@ static size_t simple_instruction(const std::string& name, const size_t offset) {
 
 /** @private */
 static size_t constant_instruction(const std::string& name,
-    const std::shared_ptr<cli::Instruction>& instruction,
+    const std::shared_ptr<CLI::Instruction>& instruction,
     const size_t offset) {
   const std::byte index{instruction->read(offset)};
-  const cli::Instruction::Value constant{instruction->read_constant(index)};
+  const CLI::Instruction::Value constant{instruction->read_constant(index)};
 
   fmt::print("{:<16} {:4d} '{}'\n", name, index, constant);
   return offset + 1;
 }
 
 size_t disassemble_instruction(
-    const std::shared_ptr<cli::Instruction>& instruction, size_t offset) {
+    const std::shared_ptr<CLI::Instruction>& instruction, size_t offset) {
   fmt::print("{:04d} ", offset);
 
-  const cli::Instruction::Code code{instruction->read(offset++)};
+  const CLI::Instruction::Code code{instruction->read(offset++)};
 
   switch (code) {
-    case cli::Instruction::Code::CONSTANT:
+    case CLI::Instruction::Code::CONSTANT:
       return constant_instruction("CONSTANT", instruction, offset);
-    case cli::Instruction::Code::DEFINE:
+    case CLI::Instruction::Code::DEFINE:
       return constant_instruction("DEFINE", instruction, offset);
-    case cli::Instruction::Code::BEGIN_SCOPE:
+    case CLI::Instruction::Code::BEGIN_SCOPE:
       return constant_instruction("BEGIN_SCOPE", instruction, offset);
-    case cli::Instruction::Code::EXECUTE:
+    case CLI::Instruction::Code::EXECUTE:
       return constant_instruction("EXECUTE", instruction, offset);
-    case cli::Instruction::Code::CLEAR:
+    case CLI::Instruction::Code::CLEAR:
       return simple_instruction("CLEAR", offset);
     default:
       fmt::print("Unknown Instruction::Code {:d}\n", code);
@@ -48,7 +48,7 @@ size_t disassemble_instruction(
   }
 }
 
-void disassemble(const std::shared_ptr<cli::Instruction>& instruction, const std::string& name) {
+void disassemble(const std::shared_ptr<CLI::Instruction>& instruction, const std::string& name) {
   fmt::print("=== {} ===\n", name);
 
   size_t offset{0};
@@ -58,4 +58,4 @@ void disassemble(const std::shared_ptr<cli::Instruction>& instruction, const std
   }
 }
 
-}  // namespace litr::debug
+}  // namespace Litr::Debug

--- a/src/core/Core/Debug/Disassembler.hpp
+++ b/src/core/Core/Debug/Disassembler.hpp
@@ -9,17 +9,17 @@
 
 #include "Core/CLI/Instruction.hpp"
 
-namespace litr::debug {
+namespace Litr::Debug {
 
-size_t disassemble_instruction(const std::shared_ptr<cli::Instruction>& instruction, size_t offset);
-void disassemble(const std::shared_ptr<cli::Instruction>& instruction, const std::string& name);
+size_t disassemble_instruction(const std::shared_ptr<CLI::Instruction>& instruction, size_t offset);
+void disassemble(const std::shared_ptr<CLI::Instruction>& instruction, const std::string& name);
 
-}  // namespace litr::debug
+}  // namespace Litr::Debug
 
 #if LITR_ENABLE_DISASSEMBLE == 1
 #define LITR_DISASSEMBLE_INSTRUCTION(instruction, offset) \
-  ::litr::debug::disassemble_instruction(instruction, offset)
-#define LITR_DISASSEMBLE(instruction, name) ::litr::debug::disassemble(instruction, name)
+  ::Litr::Debug::disassemble_instruction(instruction, offset)
+#define LITR_DISASSEMBLE(instruction, name) ::Litr::Debug::disassemble(instruction, name)
 #else
 #define LITR_DISASSEMBLE_INSTRUCTION(instruction, offset)
 #define LITR_DISASSEMBLE(instruction, name)

--- a/src/core/Core/Debug/Instrumentor.hpp
+++ b/src/core/Core/Debug/Instrumentor.hpp
@@ -15,7 +15,7 @@
 
 #include "Core/Log.hpp"
 
-namespace litr::debug {
+namespace Litr::Debug {
 
 using FloatingPointMicroseconds = std::chrono::duration<double, std::micro>;
 
@@ -163,7 +163,7 @@ class InstrumentationTimer {
   const std::chrono::time_point<std::chrono::steady_clock> m_start_time_point;
 };
 
-}  // namespace litr::debug
+}  // namespace Litr::Debug
 
 #if LITR_PROFILE
 // Resolve which function signature macro will be used. Note that this only
@@ -193,12 +193,12 @@ class InstrumentationTimer {
 
 #define JOIN_AGAIN(x, y) x##y
 #define JOIN(x, y) JOIN_AGAIN(x, y)
-#define LITR_PROFILE_BEGIN_SESSION(name) ::litr::debug::Instrumentor::get().begin_session(name)
+#define LITR_PROFILE_BEGIN_SESSION(name) ::Litr::Debug::Instrumentor::get().begin_session(name)
 #define LITR_PROFILE_BEGIN_SESSION_WITH_FILE(name, file_path) \
-  ::litr::debug::Instrumentor::get().begin_session(name, file_path)
-#define LITR_PROFILE_END_SESSION() ::litr::debug::Instrumentor::get().end_session()
+  ::Litr::Debug::Instrumentor::get().begin_session(name, file_path)
+#define LITR_PROFILE_END_SESSION() ::Litr::Debug::Instrumentor::get().end_session()
 #define LITR_PROFILE_SCOPE(name)                              \
-  ::litr::debug::InstrumentationTimer JOIN(timer, __LINE__) { \
+  ::Litr::Debug::InstrumentationTimer JOIN(timer, __LINE__) { \
     name                                                      \
   }
 #define LITR_PROFILE_FUNCTION() LITR_PROFILE_SCOPE(LITR_FUNC_SIG)

--- a/src/core/Core/Environment.hpp
+++ b/src/core/Core/Environment.hpp
@@ -6,11 +6,11 @@
 
 #include "Core/FileSystem.hpp"
 
-namespace litr {
+namespace Litr {
 
 class Environment {
  public:
   [[nodiscard]] static Path get_home_directory();
 };
 
-}  // namespace litr
+}  // namespace Litr

--- a/src/core/Core/Error/BaseError.hpp
+++ b/src/core/Core/Error/BaseError.hpp
@@ -12,9 +12,9 @@
 #include "Core/Debug/Instrumentor.hpp"
 #include "Core/Error/TomlError.hpp"
 
-namespace litr::error {
+namespace Litr::Error {
 
-// Forward declaration for `friend` declaration of litr::Error::Reporter.
+// Forward declaration for `friend` declaration of Litr::Error::Reporter.
 class Reporter;
 
 class BaseError {
@@ -50,7 +50,7 @@ class BaseError {
   }
 
   BaseError(
-      const ErrorType type, std::string message, const config::TomlFileAdapter::Value& context)
+      const ErrorType type, std::string message, const Config::TomlFileAdapter::Value& context)
       : type(type),
         message(std::move(message)),
         location(
@@ -59,7 +59,7 @@ class BaseError {
   }
 
   BaseError(
-      const ErrorType type, std::string message, const config::TomlFileAdapter::Exception& err)
+      const ErrorType type, std::string message, const Config::TomlFileAdapter::Exception& err)
       : type(type),
         message(std::move(message)),
         location(err.location().line(), err.location().column(), err.location().line_str()) {
@@ -73,12 +73,12 @@ class BaseError {
   const std::string message;
 
   std::string description{};
-  config::Location location{};
+  Config::Location location{};
 };
 
 class ReservedParamError : public BaseError {
  public:
-  ReservedParamError(const std::string& message, const config::TomlFileAdapter::Value& context)
+  ReservedParamError(const std::string& message, const Config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::RESERVED_PARAM, message, context) {
     BaseError::description = "Parameter name is reserved!";
   }
@@ -88,7 +88,7 @@ class MalformedFileError : public BaseError {
  public:
   explicit MalformedFileError(const std::string& message)
       : BaseError(ErrorType::MALFORMED_FILE, message) {}
-  MalformedFileError(const std::string& message, const config::TomlFileAdapter::Exception& err)
+  MalformedFileError(const std::string& message, const Config::TomlFileAdapter::Exception& err)
       : BaseError(ErrorType::MALFORMED_FILE, TomlError::extract_message(message, err.what()), err) {
     BaseError::description = "Invalid file format!";
   }
@@ -96,7 +96,7 @@ class MalformedFileError : public BaseError {
 
 class MalformedCommandError : public BaseError {
  public:
-  MalformedCommandError(const std::string& message, const config::TomlFileAdapter::Value& context)
+  MalformedCommandError(const std::string& message, const Config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::MALFORMED_COMMAND, message, context) {
     BaseError::description = "Command format is wrong!";
   }
@@ -104,7 +104,7 @@ class MalformedCommandError : public BaseError {
 
 class MalformedParamError : public BaseError {
  public:
-  MalformedParamError(const std::string& message, const config::TomlFileAdapter::Value& context)
+  MalformedParamError(const std::string& message, const Config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::MALFORMED_PARAM, message, context) {
     BaseError::description = "Parameter format is wrong!";
   }
@@ -112,7 +112,7 @@ class MalformedParamError : public BaseError {
 
 class MalformedScriptError : public BaseError {
  public:
-  MalformedScriptError(const std::string& message, const config::TomlFileAdapter::Value& context)
+  MalformedScriptError(const std::string& message, const Config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::MALFORMED_SCRIPT, message, context) {
     BaseError::description = "Command script is wrong!";
   }
@@ -121,7 +121,7 @@ class MalformedScriptError : public BaseError {
 class UnknownCommandPropertyError : public BaseError {
  public:
   UnknownCommandPropertyError(
-      const std::string& message, const config::TomlFileAdapter::Value& context)
+      const std::string& message, const Config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::UNKNOWN_COMMAND_PROPERTY, message, context) {
     BaseError::description = "Command property does not exist!";
   }
@@ -129,7 +129,7 @@ class UnknownCommandPropertyError : public BaseError {
 
 class UnknownParamValueError : public BaseError {
  public:
-  UnknownParamValueError(const std::string& message, const config::TomlFileAdapter::Value& context)
+  UnknownParamValueError(const std::string& message, const Config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::UNKNOWN_PARAM_VALUE, message, context) {
     BaseError::description = "Parameter value is not known!";
   }
@@ -137,7 +137,7 @@ class UnknownParamValueError : public BaseError {
 
 class ValueAlreadyInUseError : public BaseError {
  public:
-  ValueAlreadyInUseError(const std::string& message, const config::TomlFileAdapter::Value& context)
+  ValueAlreadyInUseError(const std::string& message, const Config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::VALUE_ALREADY_IN_USE, message, context) {
     BaseError::description = "Value is is already in use!";
   }
@@ -177,4 +177,4 @@ class ExecutionFailureError : public BaseError {
   }
 };
 
-}  // namespace litr::error
+}  // namespace Litr::Error

--- a/src/core/Core/Error/BaseError.hpp
+++ b/src/core/Core/Error/BaseError.hpp
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <string>
-#include <toml.hpp>
 #include <utility>
 
 #include "Core/Config/Location.hpp"
+#include "Core/Config/TomlFileAdapter.hpp"
 #include "Core/Debug/Instrumentor.hpp"
 #include "Core/Error/TomlError.hpp"
 
@@ -49,7 +49,8 @@ class BaseError {
     LITR_PROFILE_FUNCTION();
   }
 
-  BaseError(const ErrorType type, std::string message, const toml::value& context)
+  BaseError(
+      const ErrorType type, std::string message, const config::TomlFileAdapter::Value& context)
       : type(type),
         message(std::move(message)),
         location(
@@ -57,7 +58,8 @@ class BaseError {
     LITR_PROFILE_FUNCTION();
   }
 
-  BaseError(const ErrorType type, std::string message, const toml::exception& err)
+  BaseError(
+      const ErrorType type, std::string message, const config::TomlFileAdapter::Exception& err)
       : type(type),
         message(std::move(message)),
         location(err.location().line(), err.location().column(), err.location().line_str()) {
@@ -76,7 +78,7 @@ class BaseError {
 
 class ReservedParamError : public BaseError {
  public:
-  ReservedParamError(const std::string& message, const toml::value& context)
+  ReservedParamError(const std::string& message, const config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::RESERVED_PARAM, message, context) {
     BaseError::description = "Parameter name is reserved!";
   }
@@ -86,7 +88,7 @@ class MalformedFileError : public BaseError {
  public:
   explicit MalformedFileError(const std::string& message)
       : BaseError(ErrorType::MALFORMED_FILE, message) {}
-  MalformedFileError(const std::string& message, const toml::exception& err)
+  MalformedFileError(const std::string& message, const config::TomlFileAdapter::Exception& err)
       : BaseError(ErrorType::MALFORMED_FILE, TomlError::extract_message(message, err.what()), err) {
     BaseError::description = "Invalid file format!";
   }
@@ -94,7 +96,7 @@ class MalformedFileError : public BaseError {
 
 class MalformedCommandError : public BaseError {
  public:
-  MalformedCommandError(const std::string& message, const toml::value& context)
+  MalformedCommandError(const std::string& message, const config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::MALFORMED_COMMAND, message, context) {
     BaseError::description = "Command format is wrong!";
   }
@@ -102,7 +104,7 @@ class MalformedCommandError : public BaseError {
 
 class MalformedParamError : public BaseError {
  public:
-  MalformedParamError(const std::string& message, const toml::value& context)
+  MalformedParamError(const std::string& message, const config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::MALFORMED_PARAM, message, context) {
     BaseError::description = "Parameter format is wrong!";
   }
@@ -110,7 +112,7 @@ class MalformedParamError : public BaseError {
 
 class MalformedScriptError : public BaseError {
  public:
-  MalformedScriptError(const std::string& message, const toml::value& context)
+  MalformedScriptError(const std::string& message, const config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::MALFORMED_SCRIPT, message, context) {
     BaseError::description = "Command script is wrong!";
   }
@@ -118,7 +120,8 @@ class MalformedScriptError : public BaseError {
 
 class UnknownCommandPropertyError : public BaseError {
  public:
-  UnknownCommandPropertyError(const std::string& message, const toml::value& context)
+  UnknownCommandPropertyError(
+      const std::string& message, const config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::UNKNOWN_COMMAND_PROPERTY, message, context) {
     BaseError::description = "Command property does not exist!";
   }
@@ -126,7 +129,7 @@ class UnknownCommandPropertyError : public BaseError {
 
 class UnknownParamValueError : public BaseError {
  public:
-  UnknownParamValueError(const std::string& message, const toml::value& context)
+  UnknownParamValueError(const std::string& message, const config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::UNKNOWN_PARAM_VALUE, message, context) {
     BaseError::description = "Parameter value is not known!";
   }
@@ -134,7 +137,7 @@ class UnknownParamValueError : public BaseError {
 
 class ValueAlreadyInUseError : public BaseError {
  public:
-  ValueAlreadyInUseError(const std::string& message, const toml::value& context)
+  ValueAlreadyInUseError(const std::string& message, const config::TomlFileAdapter::Value& context)
       : BaseError(ErrorType::VALUE_ALREADY_IN_USE, message, context) {
     BaseError::description = "Value is is already in use!";
   }

--- a/src/core/Core/Error/Handler.cpp
+++ b/src/core/Core/Error/Handler.cpp
@@ -6,7 +6,7 @@
 
 #include "Core/Debug/Instrumentor.hpp"
 
-namespace litr::error {
+namespace Litr::Error {
 
 void Handler::push(const BaseError& err) {
   LITR_PROFILE_FUNCTION();
@@ -32,4 +32,4 @@ bool Handler::has_errors() {
   return !get().m_errors.empty();
 }
 
-}  // namespace litr::error
+}  // namespace Litr::Error

--- a/src/core/Core/Error/Handler.hpp
+++ b/src/core/Core/Error/Handler.hpp
@@ -9,7 +9,7 @@
 
 #include "Core/Error/BaseError.hpp"
 
-namespace litr::error {
+namespace Litr::Error {
 
 class Handler {
  public:
@@ -39,4 +39,4 @@ class Handler {
   Errors m_errors{};
 };
 
-}  // namespace litr::error
+}  // namespace Litr::Error

--- a/src/core/Core/Error/Reporter.cpp
+++ b/src/core/Core/Error/Reporter.cpp
@@ -14,7 +14,7 @@
 #include "Core/Debug/Instrumentor.hpp"
 #include "Core/Utils.hpp"
 
-namespace litr::error {
+namespace Litr::Error {
 
 Reporter::Reporter(Path path) : m_file_path(std::move(path)) {}
 
@@ -95,4 +95,4 @@ uint32_t Reporter::count_digits(uint32_t number) {
   return count;
 }
 
-}  // namespace litr::error
+}  // namespace Litr::Error

--- a/src/core/Core/Error/Reporter.hpp
+++ b/src/core/Core/Error/Reporter.hpp
@@ -9,7 +9,7 @@
 #include "Core/Error/BaseError.hpp"
 #include "Core/FileSystem.hpp"
 
-namespace litr::error {
+namespace Litr::Error {
 
 class Reporter {
  public:
@@ -25,4 +25,4 @@ class Reporter {
   bool m_multiple_errors{false};
 };
 
-}  // namespace litr::error
+}  // namespace Litr::Error

--- a/src/core/Core/Error/TomlError.cpp
+++ b/src/core/Core/Error/TomlError.cpp
@@ -11,7 +11,7 @@
 #include "Core/Debug/Instrumentor.hpp"
 #include "Core/Utils.hpp"
 
-namespace litr::error {
+namespace Litr::Error {
 
 std::string TomlError::extract_message(const std::string& message, const std::string& error) {
   LITR_PROFILE_FUNCTION();
@@ -36,12 +36,12 @@ bool TomlError::is_duplicated_value_error(const std::string& error) {
 std::string TomlError::extract_duplicated_value_error(const std::string& error) {
   LITR_PROFILE_FUNCTION();
 
-  const std::string extract{utils::replace(error, "[error] toml::insert_value: ", "")};
+  const std::string extract{Utils::replace(error, "[error] toml::insert_value: ", "")};
 
   // Reformat lines
   std::vector<std::string> lines{};
   std::string output{};
-  utils::split_into(extract, '\n', lines);
+  Utils::split_into(extract, '\n', lines);
 
   for (size_t i{0}; i < lines.size(); ++i) {
     // First line without change
@@ -63,7 +63,7 @@ std::string TomlError::extract_duplicated_value_error(const std::string& error) 
     output.append(lines[i]).append("\n");
   }
 
-  return utils::trim(output, '\n');
+  return Utils::trim(output, '\n');
 }
 
 bool TomlError::is_duplicated_table_error(const std::string& error) {
@@ -75,12 +75,12 @@ bool TomlError::is_duplicated_table_error(const std::string& error) {
 std::string TomlError::extract_duplicated_table_error(const std::string& error) {
   LITR_PROFILE_FUNCTION();
 
-  const std::string extract{utils::replace(error, "[error] toml::insert_value: ", "")};
+  const std::string extract{Utils::replace(error, "[error] toml::insert_value: ", "")};
 
   // Reformat lines
   std::vector<std::string> lines{};
   std::string output{};
-  utils::split_into(extract, '\n', lines);
+  Utils::split_into(extract, '\n', lines);
 
   // First line without change
   output.append(fmt::format("{}\n ...\n", lines[0]));
@@ -99,11 +99,11 @@ std::string TomlError::extract_duplicated_table_error(const std::string& error) 
     output.append(lines[i]).append("\n");
   }
 
-  return utils::trim(output, '\n');
+  return Utils::trim(output, '\n');
 }
 
 bool TomlError::is_file_reference(const std::string& line) {
   return line.find(" --> ") != std::string::npos;
 }
 
-}  // namespace litr::error
+}  // namespace Litr::Error

--- a/src/core/Core/Error/TomlError.cpp
+++ b/src/core/Core/Error/TomlError.cpp
@@ -82,13 +82,10 @@ std::string TomlError::extract_duplicated_table_error(const std::string& error) 
   std::string output{};
   utils::split_into(extract, '\n', lines);
 
-  for (size_t i{0}; i < lines.size(); ++i) {
-    // First line without change
-    if (i == 0) {
-      output.append(fmt::format("{}\n ...\n", lines[i]));
-      continue;
-    }
+  // First line without change
+  output.append(fmt::format("{}\n ...\n", lines[0]));
 
+  for (size_t i{1}; i < lines.size(); ++i) {
     if (is_file_reference(lines[i])) {
       continue;
     }

--- a/src/core/Core/Error/TomlError.hpp
+++ b/src/core/Core/Error/TomlError.hpp
@@ -6,7 +6,7 @@
 
 #include <string>
 
-namespace litr::error {
+namespace Litr::Error {
 
 class TomlError {
  public:
@@ -22,4 +22,4 @@ class TomlError {
   static bool is_file_reference(const std::string& line);
 };
 
-}  // namespace litr::error
+}  // namespace Litr::Error

--- a/src/core/Core/ExitStatus.hpp
+++ b/src/core/Core/ExitStatus.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-namespace litr {
+namespace Litr {
 
 enum class ExitStatus : int { SUCCESS = 0, FAILURE = 1 };
 
-}  // namespace litr
+}  // namespace Litr

--- a/src/core/Core/FileSystem.cpp
+++ b/src/core/Core/FileSystem.cpp
@@ -8,7 +8,7 @@
 
 #include "Core/Debug/Instrumentor.hpp"
 
-namespace litr {
+namespace Litr {
 
 // Path ------------------------------------------
 
@@ -74,4 +74,4 @@ Path FileSystem::get_current_working_directory() {
   return Path(std::filesystem::current_path());
 }
 
-}  // namespace litr
+}  // namespace Litr

--- a/src/core/Core/FileSystem.hpp
+++ b/src/core/Core/FileSystem.hpp
@@ -10,7 +10,7 @@
 #include <filesystem>
 #include <string>
 
-namespace litr {
+namespace Litr {
 
 class Path {
  public:
@@ -78,18 +78,18 @@ class FileSystem {
   [[nodiscard]] static Path get_current_working_directory();
 };
 
-}  // namespace litr
+}  // namespace Litr
 
 // Enable easy formatting with fmt
 template <>
-struct fmt::formatter<litr::Path> {
+struct fmt::formatter<Litr::Path> {
   template <typename ParseContext>
   constexpr auto parse(ParseContext& ctx) {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  auto format(const litr::Path& path, FormatContext& ctx) {
+  auto format(const Litr::Path& path, FormatContext& ctx) {
     return format_to(ctx.out(), "{}", path.to_string());
   }
 };

--- a/src/core/Core/Log.cpp
+++ b/src/core/Core/Log.cpp
@@ -9,7 +9,7 @@
 
 #include <vector>
 
-namespace litr {
+namespace Litr {
 
 Log::Log() {
   std::vector<spdlog::sink_ptr> log_sinks;
@@ -38,4 +38,4 @@ Log::Log() {
   m_client_logger->flush_on(level);
 }
 
-}  // namespace litr
+}  // namespace Litr

--- a/src/core/Core/Log.hpp
+++ b/src/core/Core/Log.hpp
@@ -9,7 +9,7 @@
 
 #include <memory>
 
-namespace litr {
+namespace Litr {
 
 class Log {
  public:
@@ -42,39 +42,39 @@ class Log {
   std::shared_ptr<spdlog::logger> m_client_logger;
 };
 
-}  // namespace litr
+}  // namespace Litr
 
 // Core logging
 
 #ifndef LITR_DEACTIVATE_LOGGING
 
 #if DEBUG
-#define LITR_CORE_TRACE(...) ::litr::Log::get_core_logger()->trace(__VA_ARGS__)
-#define LITR_CORE_DEBUG(...) ::litr::Log::get_core_logger()->debug(__VA_ARGS__)
+#define LITR_CORE_TRACE(...) ::Litr::Log::get_core_logger()->trace(__VA_ARGS__)
+#define LITR_CORE_DEBUG(...) ::Litr::Log::get_core_logger()->debug(__VA_ARGS__)
 #else
 #define LITR_CORE_TRACE(...)
 #define LITR_CORE_DEBUG(...)
 #endif
 
-#define LITR_CORE_INFO(...) ::litr::Log::get_core_logger()->info(__VA_ARGS__)
-#define LITR_CORE_WARN(...) ::litr::Log::get_core_logger()->warn(__VA_ARGS__)
-#define LITR_CORE_ERROR(...) ::litr::Log::get_core_logger()->error(__VA_ARGS__)
-#define LITR_CORE_FATAL(...) ::litr::Log::get_core_logger()->fatal(__VA_ARGS__)
+#define LITR_CORE_INFO(...) ::Litr::Log::get_core_logger()->info(__VA_ARGS__)
+#define LITR_CORE_WARN(...) ::Litr::Log::get_core_logger()->warn(__VA_ARGS__)
+#define LITR_CORE_ERROR(...) ::Litr::Log::get_core_logger()->error(__VA_ARGS__)
+#define LITR_CORE_FATAL(...) ::Litr::Log::get_core_logger()->fatal(__VA_ARGS__)
 
 // Client logging
 
 #if DEBUG
-#define LITR_TRACE(...) ::litr::Log::get_client_logger()->trace(__VA_ARGS__)
-#define LITR_DEBUG(...) ::litr::Log::get_client_logger()->debug(__VA_ARGS__)
+#define LITR_TRACE(...) ::Litr::Log::get_client_logger()->trace(__VA_ARGS__)
+#define LITR_DEBUG(...) ::Litr::Log::get_client_logger()->debug(__VA_ARGS__)
 #else
 #define LITR_TRACE(...)
 #define LITR_DEBUG(...)
 #endif
 
-#define LITR_INFO(...) ::litr::Log::get_client_logger()->info(__VA_ARGS__)
-#define LITR_WARN(...) ::litr::Log::get_client_logger()->warn(__VA_ARGS__)
-#define LITR_ERROR(...) ::litr::Log::get_client_logger()->error(__VA_ARGS__)
-#define LITR_FATAL(...) ::litr::Log::get_client_logger()->fatal(__VA_ARGS__)
+#define LITR_INFO(...) ::Litr::Log::get_client_logger()->info(__VA_ARGS__)
+#define LITR_WARN(...) ::Litr::Log::get_client_logger()->warn(__VA_ARGS__)
+#define LITR_ERROR(...) ::Litr::Log::get_client_logger()->error(__VA_ARGS__)
+#define LITR_FATAL(...) ::Litr::Log::get_client_logger()->fatal(__VA_ARGS__)
 
 #else
 

--- a/src/core/Core/Script/Compiler.cpp
+++ b/src/core/Core/Script/Compiler.cpp
@@ -13,9 +13,9 @@
 #include "Core/Error/Handler.hpp"
 #include "Core/Utils.hpp"
 
-namespace litr::script {
+namespace Litr::Script {
 
-Compiler::Compiler(const std::string& source, config::Location location, Variables variables)
+Compiler::Compiler(const std::string& source, Config::Location location, Variables variables)
     : m_scanner(source.c_str()),
       m_location(std::move(location)),
       m_variables(std::move(variables)) {
@@ -142,17 +142,17 @@ void Compiler::identifier() {
   collect_used_variable(variable->second);
 
   switch (variable->second.type) {
-    case cli::Variable::Type::STRING:
+    case CLI::Variable::Type::STRING:
       string(variable->second);
       break;
-    case cli::Variable::Type::BOOLEAN:
+    case CLI::Variable::Type::BOOLEAN:
       statement(variable->second);
       break;
   }
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-void Compiler::statement(const cli::Variable& variable) {
+void Compiler::statement(const CLI::Variable& variable) {
   LITR_PROFILE_FUNCTION();
 
   advance();
@@ -165,7 +165,7 @@ void Compiler::statement(const cli::Variable& variable) {
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-void Compiler::or_statement(const cli::Variable& variable) {
+void Compiler::or_statement(const CLI::Variable& variable) {
   LITR_PROFILE_FUNCTION();
 
   if (std::get<bool>(variable.value)) {
@@ -186,7 +186,7 @@ void Compiler::or_statement(const cli::Variable& variable) {
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-void Compiler::if_statement(const cli::Variable& variable) {
+void Compiler::if_statement(const CLI::Variable& variable) {
   LITR_PROFILE_FUNCTION();
 
   if (std::get<bool>(variable.value)) {
@@ -212,10 +212,10 @@ void Compiler::expression() {
 void Compiler::string() {
   LITR_PROFILE_FUNCTION();
 
-  m_script.append(utils::trim(Scanner::get_token_value(m_previous), '\''));
+  m_script.append(Utils::trim(Scanner::get_token_value(m_previous), '\''));
 }
 
-void Compiler::string(const cli::Variable& variable) {
+void Compiler::string(const CLI::Variable& variable) {
   LITR_PROFILE_FUNCTION();
 
   m_script.append(std::get<std::string>(variable.value));
@@ -233,7 +233,7 @@ void Compiler::end_of_script() {
   consume(TokenType::EOS, "Expected end.");
 }
 
-void Compiler::collect_used_variable(const cli::Variable& variable) {
+void Compiler::collect_used_variable(const CLI::Variable& variable) {
   // If name is not already collected:
   if (std::find(m_used_variables.begin(), m_used_variables.end(), variable.name) ==
       m_used_variables.end()) {
@@ -273,8 +273,8 @@ void Compiler::error_at(Token* token, const std::string& message) {
 
   out_message.append(fmt::format(": {}", message));
 
-  error::Handler::push(error::ScriptParserError(
+  Error::Handler::push(Error::ScriptParserError(
       out_message, m_location.line, m_location.column + token->column + 1, m_location.line_str));
 }
 
-}  // namespace litr::script
+}  // namespace Litr::Script

--- a/src/core/Core/Script/Compiler.hpp
+++ b/src/core/Core/Script/Compiler.hpp
@@ -13,13 +13,13 @@
 #include "Core/Script/Scanner.hpp"
 #include "Core/Script/Token.hpp"
 
-namespace litr::script {
+namespace Litr::Script {
 
 class Compiler {
  public:
-  using Variables = std::unordered_map<std::string, cli::Variable>;
+  using Variables = std::unordered_map<std::string, CLI::Variable>;
 
-  Compiler(const std::string& source, config::Location location, Variables variables);
+  Compiler(const std::string& source, Config::Location location, Variables variables);
 
   [[nodiscard]] std::string get_script() const;
   [[nodiscard]] std::vector<std::string> get_used_variables() const;
@@ -36,24 +36,24 @@ class Compiler {
   void script();
   void identifier();
 
-  void statement(const cli::Variable& variable);
-  void or_statement(const cli::Variable& variable);
-  void if_statement(const cli::Variable& variable);
+  void statement(const CLI::Variable& variable);
+  void or_statement(const CLI::Variable& variable);
+  void if_statement(const CLI::Variable& variable);
 
   void expression();
   void string();
-  void string(const cli::Variable& variable);
+  void string(const CLI::Variable& variable);
   void end_of_sequence();
   void end_of_script();
 
-  void collect_used_variable(const cli::Variable& variable);
+  void collect_used_variable(const CLI::Variable& variable);
 
   void error(const std::string& message);
   void error_at_current(const std::string& message);
   void error_at(Token* token, const std::string& message);
 
   Scanner m_scanner;
-  const config::Location m_location;
+  const Config::Location m_location;
   Variables m_variables;
 
   Token m_current{};
@@ -64,4 +64,4 @@ class Compiler {
   std::vector<std::string> m_used_variables{};
 };
 
-}  // namespace litr::script
+}  // namespace Litr::Script

--- a/src/core/Core/Script/Scanner.cpp
+++ b/src/core/Core/Script/Scanner.cpp
@@ -8,7 +8,7 @@
 
 #include "Core/Debug/Instrumentor.hpp"
 
-namespace litr::script {
+namespace Litr::Script {
 
 Scanner::Scanner(const char* source) : m_start(source), m_current(source) {}
 
@@ -260,4 +260,4 @@ TokenType Scanner::check_keyword(
   return TokenType::IDENTIFIER;
 }
 
-}  // namespace litr::script
+}  // namespace Litr::Script

--- a/src/core/Core/Script/Scanner.hpp
+++ b/src/core/Core/Script/Scanner.hpp
@@ -9,7 +9,7 @@
 
 #include "Core/Script/Token.hpp"
 
-namespace litr::script {
+namespace Litr::Script {
 
 class Scanner {
  public:
@@ -57,4 +57,4 @@ class Scanner {
   std::stack<Mode> m_modes{{Mode::UNTOUCHED}};
 };
 
-}  // namespace litr::script
+}  // namespace Litr::Script

--- a/src/core/Core/Script/Token.hpp
+++ b/src/core/Core/Script/Token.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-namespace litr::script {
+namespace Litr::Script {
 
 enum class TokenType {
   // Single-character tokens.
@@ -34,4 +34,4 @@ struct Token {
   uint32_t column{};
 };
 
-}  // namespace litr::script
+}  // namespace Litr::Script

--- a/src/core/Core/Utils.cpp
+++ b/src/core/Core/Utils.cpp
@@ -8,7 +8,7 @@
 
 #include "Core/Debug/Instrumentor.hpp"
 
-namespace litr::utils {
+namespace Litr::Utils {
 
 std::string trim_left(const std::string& src, char character) {
   LITR_PROFILE_FUNCTION();
@@ -74,4 +74,4 @@ std::string replace(const std::string& source, const std::string& from, const st
   return extract;
 }
 
-}  // namespace litr::utils
+}  // namespace Litr::Utils

--- a/src/core/Core/Utils.hpp
+++ b/src/core/Core/Utils.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-namespace litr::utils {
+namespace Litr::Utils {
 
 [[nodiscard]] std::string trim_left(const std::string& src, char character);
 [[nodiscard]] std::string trim_right(const std::string& src, char character);
@@ -22,4 +22,4 @@ void deduplicate(std::vector<std::string>& items);
 
 std::string replace(const std::string& source, const std::string& from, const std::string& to);
 
-}  // namespace litr::utils
+}  // namespace Litr::Utils

--- a/src/core/Platform/LinuxEnvironment.cpp
+++ b/src/core/Platform/LinuxEnvironment.cpp
@@ -7,7 +7,7 @@
 #include "Core/Debug/Instrumentor.hpp"
 #include "Core/Environment.hpp"
 
-namespace litr {
+namespace Litr {
 
 Path Environment::get_home_directory() {
   LITR_PROFILE_FUNCTION();
@@ -17,4 +17,4 @@ Path Environment::get_home_directory() {
   return Path(std::getenv("HOME"));
 }
 
-}  // namespace litr
+}  // namespace Litr

--- a/src/core/Platform/MacEnvironment.cpp
+++ b/src/core/Platform/MacEnvironment.cpp
@@ -9,7 +9,7 @@
 #include "Core/Debug/Instrumentor.hpp"
 #include "Core/Environment.hpp"
 
-namespace litr {
+namespace Litr {
 
 static Path user_path(const std::string& user_name) {
   Path path{fmt::format("/Users/{}", user_name)};
@@ -36,4 +36,4 @@ Path Environment::get_home_directory() {
   return {};
 }
 
-}  // namespace litr
+}  // namespace Litr

--- a/src/core/Platform/WindowsEnvironment.cpp
+++ b/src/core/Platform/WindowsEnvironment.cpp
@@ -7,7 +7,7 @@
 #include "Core/Debug/Instrumentor.hpp"
 #include "Core/Environment.hpp"
 
-namespace litr {
+namespace Litr {
 
 Path Environment::get_home_directory() {
   LITR_PROFILE_FUNCTION();
@@ -17,4 +17,4 @@ Path Environment::get_home_directory() {
   return Path(std::getenv("HOMEPATH"));
 }
 
-}  // namespace litr
+}  // namespace Litr

--- a/src/tests/Helpers/TOML.cpp
+++ b/src/tests/Helpers/TOML.cpp
@@ -15,7 +15,7 @@ TomlMock create_toml_mock(const std::string& name, const std::string& toml) {
       name,
       toml)};
 
-  litr::config::TomlFileAdapter file{};
+  Litr::Config::TomlFileAdapter file{};
 
   std::istringstream is_context(r_context, std::ios_base::binary | std::ios_base::in);
   const auto context =

--- a/src/tests/Helpers/TOML.cpp
+++ b/src/tests/Helpers/TOML.cpp
@@ -9,8 +9,7 @@
 
 #include <toml.hpp>
 
-std::pair<litr::config::TomlFileAdapter::Table, litr::config::TomlFileAdapter::Value>
-create_toml_mock(const std::string& name, const std::string& toml) {
+TomlMock create_toml_mock(const std::string& name, const std::string& toml) {
   std::string r_context{fmt::format(R"([{}]
 {})",
       name,
@@ -25,5 +24,5 @@ create_toml_mock(const std::string& name, const std::string& toml) {
   std::istringstream is_data(toml, std::ios_base::binary | std::ios_base::in);
   const auto data = toml::parse<toml::discard_comments, tsl::ordered_map>(is_data, "std::string");
 
-  return {context.as_table(), data};
+  return {context, data};
 }

--- a/src/tests/Helpers/TOML.cpp
+++ b/src/tests/Helpers/TOML.cpp
@@ -5,19 +5,25 @@
 #include "TOML.hpp"
 
 #include <fmt/format.h>
+#include <tsl/ordered_map.h>
 
-std::pair<toml::table, toml::value> create_toml_mock(
-    const std::string& name, const std::string& toml) {
-  std::string r_file{fmt::format(R"([{}]
+#include <toml.hpp>
+
+std::pair<litr::config::TomlFileAdapter::Table, litr::config::TomlFileAdapter::Value>
+create_toml_mock(const std::string& name, const std::string& toml) {
+  std::string r_context{fmt::format(R"([{}]
 {})",
       name,
       toml)};
 
-  std::istringstream is_file(r_file, std::ios_base::binary | std::ios_base::in);
-  const auto file = toml::parse(is_file, "std::string");
+  litr::config::TomlFileAdapter file{};
+
+  std::istringstream is_context(r_context, std::ios_base::binary | std::ios_base::in);
+  const auto context =
+      toml::parse<toml::discard_comments, tsl::ordered_map>(is_context, "std::string");
 
   std::istringstream is_data(toml, std::ios_base::binary | std::ios_base::in);
-  const auto data = toml::parse(is_data, "std::string");
+  const auto data = toml::parse<toml::discard_comments, tsl::ordered_map>(is_data, "std::string");
 
-  return {file.as_table(), data};
+  return {context.as_table(), data};
 }

--- a/src/tests/Helpers/TOML.hpp
+++ b/src/tests/Helpers/TOML.hpp
@@ -5,9 +5,12 @@
 #pragma once
 
 #include <string>
-#include <utility>
 
 #include "Core/Config/TomlFileAdapter.hpp"
 
-std::pair<litr::config::TomlFileAdapter::Table, litr::config::TomlFileAdapter::Value>
-create_toml_mock(const std::string& name, const std::string& toml);
+struct TomlMock {
+  litr::config::TomlFileAdapter::Value context;
+  litr::config::TomlFileAdapter::Value data;
+};
+
+TomlMock create_toml_mock(const std::string& name, const std::string& toml);

--- a/src/tests/Helpers/TOML.hpp
+++ b/src/tests/Helpers/TOML.hpp
@@ -1,12 +1,13 @@
 /*
- * Copyright (c) 2020 Martin Helmut Fieber <info@martin-fieber.se>
+ * Copyright (c) 2020-2022 Martin Helmut Fieber <info@martin-fieber.se>
  */
 
 #pragma once
 
 #include <string>
-#include <toml.hpp>
 #include <utility>
 
-std::pair<toml::table, toml::value> create_toml_mock(
-    const std::string& name, const std::string& toml);
+#include "Core/Config/TomlFileAdapter.hpp"
+
+std::pair<litr::config::TomlFileAdapter::Table, litr::config::TomlFileAdapter::Value>
+create_toml_mock(const std::string& name, const std::string& toml);

--- a/src/tests/Helpers/TOML.hpp
+++ b/src/tests/Helpers/TOML.hpp
@@ -9,8 +9,8 @@
 #include "Core/Config/TomlFileAdapter.hpp"
 
 struct TomlMock {
-  litr::config::TomlFileAdapter::Value context;
-  litr::config::TomlFileAdapter::Value data;
+  Litr::Config::TomlFileAdapter::Value context;
+  Litr::Config::TomlFileAdapter::Value data;
 };
 
 TomlMock create_toml_mock(const std::string& name, const std::string& toml);

--- a/src/tests/Tests/Core/CLI/Parser.unit.cpp
+++ b/src/tests/Tests/Core/CLI/Parser.unit.cpp
@@ -19,20 +19,20 @@
     size_t offset{0};                                                                        \
     while (offset < (instruction)->count()) {                                                \
       const auto test{(definition)[iteration]};                                              \
-      const litr::cli::Instruction::Code code{(instruction)->read(offset++)};                \
+      const Litr::CLI::Instruction::Code code{(instruction)->read(offset++)};                \
       switch (code) {                                                                        \
-        case litr::cli::Instruction::Code::CONSTANT:                                         \
-        case litr::cli::Instruction::Code::DEFINE:                                           \
-        case litr::cli::Instruction::Code::BEGIN_SCOPE:                                      \
-        case litr::cli::Instruction::Code::EXECUTE: {                                        \
+        case Litr::CLI::Instruction::Code::CONSTANT:                                         \
+        case Litr::CLI::Instruction::Code::DEFINE:                                           \
+        case Litr::CLI::Instruction::Code::BEGIN_SCOPE:                                      \
+        case Litr::CLI::Instruction::Code::EXECUTE: {                                        \
           const std::byte index{(instruction)->read(offset)};                                \
-          const litr::cli::Instruction::Value constant{(instruction)->read_constant(index)}; \
+          const Litr::CLI::Instruction::Value constant{(instruction)->read_constant(index)}; \
           offset += 1;                                                                       \
           CHECK_EQ(test.code, code);                                                         \
           CHECK_EQ(test.value, constant);                                                    \
           break;                                                                             \
         }                                                                                    \
-        case litr::cli::Instruction::Code::CLEAR: {                                          \
+        case Litr::CLI::Instruction::Code::CLEAR: {                                          \
           CHECK_EQ(test.code, code);                                                         \
           break;                                                                             \
         }                                                                                    \
@@ -46,375 +46,375 @@
   }
 
 struct InstructionDefinition {
-  litr::cli::Instruction::Code code;
-  litr::cli::Instruction::Value value;
+  Litr::CLI::Instruction::Code code;
+  Litr::CLI::Instruction::Value value;
 };
 
 TEST_SUITE("CLI::Parser") {
   TEST_CASE("Single long parameter") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(--target="Some release")"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
     const std::array<InstructionDefinition, 2> definition{
-        {{litr::cli::Instruction::Code::DEFINE, "target"},
-            {litr::cli::Instruction::Code::CONSTANT, "Some release"}}};
+        {{Litr::CLI::Instruction::Code::DEFINE, "target"},
+            {Litr::CLI::Instruction::Code::CONSTANT, "Some release"}}};
 
     CHECK_FALSE(parser.has_errors());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     CHECK_DEFINITION(instruction, definition);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Single short parameter") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(-t="debug is nice")"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
     const std::array<InstructionDefinition, 2> definition{
-        {{litr::cli::Instruction::Code::DEFINE, "t"},
-            {litr::cli::Instruction::Code::CONSTANT, "debug is nice"}}};
+        {{Litr::CLI::Instruction::Code::DEFINE, "t"},
+            {Litr::CLI::Instruction::Code::CONSTANT, "debug is nice"}}};
 
     CHECK_FALSE(parser.has_errors());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     CHECK_DEFINITION(instruction, definition);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Parameter with empty string") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(-t="")"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
     const std::array<InstructionDefinition, 2> definition{
-        {{litr::cli::Instruction::Code::DEFINE, "t"},
-            {litr::cli::Instruction::Code::CONSTANT, ""}}};
+        {{Litr::CLI::Instruction::Code::DEFINE, "t"},
+            {Litr::CLI::Instruction::Code::CONSTANT, ""}}};
 
     CHECK_FALSE(parser.has_errors());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     CHECK_DEFINITION(instruction, definition);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Single command") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{"build"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
     const std::array<InstructionDefinition, 2> definition{
-        {{litr::cli::Instruction::Code::BEGIN_SCOPE, "build"},
-            {litr::cli::Instruction::Code::EXECUTE, "build"}}};
+        {{Litr::CLI::Instruction::Code::BEGIN_SCOPE, "build"},
+            {Litr::CLI::Instruction::Code::EXECUTE, "build"}}};
 
     CHECK_FALSE(parser.has_errors());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     CHECK_DEFINITION(instruction, definition);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Multiple commands") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{"build cpp"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
     const std::array<InstructionDefinition, 3> definition{
-        {{litr::cli::Instruction::Code::BEGIN_SCOPE, "build"},
-            {litr::cli::Instruction::Code::BEGIN_SCOPE, "cpp"},
-            {litr::cli::Instruction::Code::EXECUTE, "build.cpp"}}};
+        {{Litr::CLI::Instruction::Code::BEGIN_SCOPE, "build"},
+            {Litr::CLI::Instruction::Code::BEGIN_SCOPE, "cpp"},
+            {Litr::CLI::Instruction::Code::EXECUTE, "build.cpp"}}};
 
     CHECK_FALSE(parser.has_errors());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     CHECK_DEFINITION(instruction, definition);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Multiple comma separated commands") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{"build,run"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
     const std::array<InstructionDefinition, 5> definition{
-        {{litr::cli::Instruction::Code::BEGIN_SCOPE, "build"},
-            {litr::cli::Instruction::Code::EXECUTE, "build"},
-            {litr::cli::Instruction::Code::CLEAR, NO_VALUE},
-            {litr::cli::Instruction::Code::BEGIN_SCOPE, "run"},
-            {litr::cli::Instruction::Code::EXECUTE, "run"}}};
+        {{Litr::CLI::Instruction::Code::BEGIN_SCOPE, "build"},
+            {Litr::CLI::Instruction::Code::EXECUTE, "build"},
+            {Litr::CLI::Instruction::Code::CLEAR, NO_VALUE},
+            {Litr::CLI::Instruction::Code::BEGIN_SCOPE, "run"},
+            {Litr::CLI::Instruction::Code::EXECUTE, "run"}}};
 
     CHECK_FALSE(parser.has_errors());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     CHECK_DEFINITION(instruction, definition);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Long parameter with string values and commands") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(--target="release" build,run)"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
     const std::array<InstructionDefinition, 7> definition{
-        {{litr::cli::Instruction::Code::DEFINE, "target"},
-            {litr::cli::Instruction::Code::CONSTANT, "release"},
-            {litr::cli::Instruction::Code::BEGIN_SCOPE, "build"},
-            {litr::cli::Instruction::Code::EXECUTE, "build"},
-            {litr::cli::Instruction::Code::CLEAR, NO_VALUE},
-            {litr::cli::Instruction::Code::BEGIN_SCOPE, "run"},
-            {litr::cli::Instruction::Code::EXECUTE, "run"}}};
+        {{Litr::CLI::Instruction::Code::DEFINE, "target"},
+            {Litr::CLI::Instruction::Code::CONSTANT, "release"},
+            {Litr::CLI::Instruction::Code::BEGIN_SCOPE, "build"},
+            {Litr::CLI::Instruction::Code::EXECUTE, "build"},
+            {Litr::CLI::Instruction::Code::CLEAR, NO_VALUE},
+            {Litr::CLI::Instruction::Code::BEGIN_SCOPE, "run"},
+            {Litr::CLI::Instruction::Code::EXECUTE, "run"}}};
 
     CHECK_FALSE(parser.has_errors());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     CHECK_DEFINITION(instruction, definition);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Mixed parameters with mixed values") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(-t="release" --debug)"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
     const std::array<InstructionDefinition, 3> definition{
-        {{litr::cli::Instruction::Code::DEFINE, "t"},
-            {litr::cli::Instruction::Code::CONSTANT, "release"},
-            {litr::cli::Instruction::Code::DEFINE, "debug"}}};
+        {{Litr::CLI::Instruction::Code::DEFINE, "t"},
+            {Litr::CLI::Instruction::Code::CONSTANT, "release"},
+            {Litr::CLI::Instruction::Code::DEFINE, "debug"}}};
 
     CHECK_FALSE(parser.has_errors());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     CHECK_DEFINITION(instruction, definition);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Invalid comma operator") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{","};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors() == true);
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `,`: Unexpected comma.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Invalid comma operators with parameter") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(-t="debug" ,)"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `,`: Unexpected comma.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Invalid comma operators with command") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{"run ,,"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `,`: Duplicated comma.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Invalid multiple comma operators") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{", ,"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `,`: Unexpected comma.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Invalid multiple comma operators with commands") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{"build cpp , ,"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `,`: Duplicated comma.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Even more invalid multiple comma operators with commands") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{"build cpp ,,,,"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `,`: Duplicated comma.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Invalid multiple comma operators with closing command") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{"build cpp , , run"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `,`: Duplicated comma.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Valid nested command execution") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(-t="debug" build cpp)"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
     const std::array<InstructionDefinition, 5> definition{
-        {{litr::cli::Instruction::Code::DEFINE, "t"},
-            {litr::cli::Instruction::Code::CONSTANT, "debug"},
-            {litr::cli::Instruction::Code::BEGIN_SCOPE, "build"},
-            {litr::cli::Instruction::Code::BEGIN_SCOPE, "cpp"},
-            {litr::cli::Instruction::Code::EXECUTE, "build.cpp"}}};
+        {{Litr::CLI::Instruction::Code::DEFINE, "t"},
+            {Litr::CLI::Instruction::Code::CONSTANT, "debug"},
+            {Litr::CLI::Instruction::Code::BEGIN_SCOPE, "build"},
+            {Litr::CLI::Instruction::Code::BEGIN_SCOPE, "cpp"},
+            {Litr::CLI::Instruction::Code::EXECUTE, "build.cpp"}}};
 
     CHECK_FALSE(parser.has_errors());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     CHECK_DEFINITION(instruction, definition);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Valid multiple nested command execution") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(-t="debug" build cpp, java)"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
     const std::array<InstructionDefinition, 8> definition{
-        {{litr::cli::Instruction::Code::DEFINE, "t"},
-            {litr::cli::Instruction::Code::CONSTANT, "debug"},
-            {litr::cli::Instruction::Code::BEGIN_SCOPE, "build"},
-            {litr::cli::Instruction::Code::BEGIN_SCOPE, "cpp"},
-            {litr::cli::Instruction::Code::EXECUTE, "build.cpp"},
-            {litr::cli::Instruction::Code::CLEAR, NO_VALUE},
-            {litr::cli::Instruction::Code::BEGIN_SCOPE, "java"},
-            {litr::cli::Instruction::Code::EXECUTE, "build.java"}}};
+        {{Litr::CLI::Instruction::Code::DEFINE, "t"},
+            {Litr::CLI::Instruction::Code::CONSTANT, "debug"},
+            {Litr::CLI::Instruction::Code::BEGIN_SCOPE, "build"},
+            {Litr::CLI::Instruction::Code::BEGIN_SCOPE, "cpp"},
+            {Litr::CLI::Instruction::Code::EXECUTE, "build.cpp"},
+            {Litr::CLI::Instruction::Code::CLEAR, NO_VALUE},
+            {Litr::CLI::Instruction::Code::BEGIN_SCOPE, "java"},
+            {Litr::CLI::Instruction::Code::EXECUTE, "build.java"}}};
 
     CHECK_FALSE(parser.has_errors());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     CHECK_DEFINITION(instruction, definition);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Unsupported characters") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{"(9)"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse: Unexpected character.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Unsupported string between commands") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(build "debug" project )"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `\"debug\"`: This is not allowed here.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Unsupported number between commands") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(build 23 project )"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `23`: This is not allowed here.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Unsupported characters between commands") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(build ++ project )"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse: Unexpected character.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Assignment missing parameter") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(= "value")"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message,
         "Cannot parse at `=`: You are missing a parameter in front of the assignment.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Duplicated assignment operator") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{R"(-t == "value")"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `=`: Value assignment missing.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Duplicated parameter initializer") {
-    const auto instruction{std::make_shared<litr::cli::Instruction>()};
+    const auto instruction{std::make_shared<Litr::CLI::Instruction>()};
     const std::string source{"---t"};
 
-    litr::cli::Parser parser{instruction, source};
+    Litr::CLI::Parser parser{instruction, source};
 
     CHECK(parser.has_errors());
 
-    const auto errors{litr::error::Handler::get_errors()};
+    const auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(
         errors[0].message, "Cannot parse: A parameter can only start with the characters A-Za-z.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 }

--- a/src/tests/Tests/Core/CLI/Scanner.unit.cpp
+++ b/src/tests/Tests/Core/CLI/Scanner.unit.cpp
@@ -15,59 +15,59 @@
 #define CHECK_DEFINITION(scanner, definition)                           \
   {                                                                     \
     for (auto&& test : (definition)) {                                  \
-      litr::cli::Token token{(scanner).scan_token()};                   \
+      Litr::CLI::Token token{(scanner).scan_token()};                   \
       CHECK_EQ(token.type, test.type);                                  \
-      CHECK_EQ(litr::cli::Scanner::get_token_value(token), test.value); \
+      CHECK_EQ(Litr::CLI::Scanner::get_token_value(token), test.value); \
     }                                                                   \
   }
 
 #define CHECK_EOS_TOKEN(scanner)                            \
   {                                                         \
-    litr::cli::Token eos{(scanner).scan_token()};           \
-    CHECK_EQ(eos.type, litr::cli::TokenType::EOS);          \
-    CHECK_EQ(litr::cli::Scanner::get_token_value(eos), ""); \
+    Litr::CLI::Token eos{(scanner).scan_token()};           \
+    CHECK_EQ(eos.type, Litr::CLI::TokenType::EOS);          \
+    CHECK_EQ(Litr::CLI::Scanner::get_token_value(eos), ""); \
   }
 
 struct TokenDefinition {
-  litr::cli::TokenType type;
+  Litr::CLI::TokenType type;
   std::string value;
 };
 
 TEST_SUITE("CLI::Scanner") {
   // Successful cases
   TEST_CASE("Single long parameter") {
-    litr::cli::Scanner scanner{"--help"};
+    Litr::CLI::Scanner scanner{"--help"};
 
-    std::array<TokenDefinition, 1> definition{{{litr::cli::TokenType::LONG_PARAMETER, "--help"}}};
+    std::array<TokenDefinition, 1> definition{{{Litr::CLI::TokenType::LONG_PARAMETER, "--help"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Single short parameter") {
-    litr::cli::Scanner scanner{"-h"};
+    Litr::CLI::Scanner scanner{"-h"};
 
-    std::array<TokenDefinition, 1> definition{{{litr::cli::TokenType::SHORT_PARAMETER, "-h"}}};
+    std::array<TokenDefinition, 1> definition{{{Litr::CLI::TokenType::SHORT_PARAMETER, "-h"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Single command") {
-    litr::cli::Scanner scanner{"build"};
+    Litr::CLI::Scanner scanner{"build"};
 
-    std::array<TokenDefinition, 1> definition{{{litr::cli::TokenType::COMMAND, "build"}}};
+    std::array<TokenDefinition, 1> definition{{{Litr::CLI::TokenType::COMMAND, "build"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Multiple commands") {
-    litr::cli::Scanner scanner{"build cpp"};
+    Litr::CLI::Scanner scanner{"build cpp"};
 
     std::array<TokenDefinition, 2> definition{{
-        {litr::cli::TokenType::COMMAND, "build"},
-        {litr::cli::TokenType::COMMAND, "cpp"},
+        {Litr::CLI::TokenType::COMMAND, "build"},
+        {Litr::CLI::TokenType::COMMAND, "cpp"},
     }};
 
     CHECK_DEFINITION(scanner, definition);
@@ -75,124 +75,124 @@ TEST_SUITE("CLI::Scanner") {
   }
 
   TEST_CASE("More multiple commands with whitespace") {
-    litr::cli::Scanner scanner{"build cpp   another"};
+    Litr::CLI::Scanner scanner{"build cpp   another"};
 
-    std::array<TokenDefinition, 3> definition{{{litr::cli::TokenType::COMMAND, "build"},
-        {litr::cli::TokenType::COMMAND, "cpp"},
-        {litr::cli::TokenType::COMMAND, "another"}}};
+    std::array<TokenDefinition, 3> definition{{{Litr::CLI::TokenType::COMMAND, "build"},
+        {Litr::CLI::TokenType::COMMAND, "cpp"},
+        {Litr::CLI::TokenType::COMMAND, "another"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Multiple comma separated commands") {
-    litr::cli::Scanner scanner{"build,run"};
+    Litr::CLI::Scanner scanner{"build,run"};
 
-    std::array<TokenDefinition, 3> definition{{{litr::cli::TokenType::COMMAND, "build"},
-        {litr::cli::TokenType::COMMA, ","},
-        {litr::cli::TokenType::COMMAND, "run"}}};
+    std::array<TokenDefinition, 3> definition{{{Litr::CLI::TokenType::COMMAND, "build"},
+        {Litr::CLI::TokenType::COMMA, ","},
+        {Litr::CLI::TokenType::COMMAND, "run"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Multiple comma separated commands with whitespace") {
-    litr::cli::Scanner scanner{"build ,  run"};
+    Litr::CLI::Scanner scanner{"build ,  run"};
 
-    std::array<TokenDefinition, 3> definition{{{litr::cli::TokenType::COMMAND, "build"},
-        {litr::cli::TokenType::COMMA, ","},
-        {litr::cli::TokenType::COMMAND, "run"}}};
+    std::array<TokenDefinition, 3> definition{{{Litr::CLI::TokenType::COMMAND, "build"},
+        {Litr::CLI::TokenType::COMMA, ","},
+        {Litr::CLI::TokenType::COMMAND, "run"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Long parameter with string values") {
-    litr::cli::Scanner scanner{" --target=\"release value\" build,run"};
+    Litr::CLI::Scanner scanner{" --target=\"release value\" build,run"};
 
     constexpr int item_count{6};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::cli::TokenType::LONG_PARAMETER, "--target"},
-            {litr::cli::TokenType::EQUAL, "="},
-            {litr::cli::TokenType::STRING, "\"release value\""},
-            {litr::cli::TokenType::COMMAND, "build"},
-            {litr::cli::TokenType::COMMA, ","},
-            {litr::cli::TokenType::COMMAND, "run"}}};
+        {{Litr::CLI::TokenType::LONG_PARAMETER, "--target"},
+            {Litr::CLI::TokenType::EQUAL, "="},
+            {Litr::CLI::TokenType::STRING, "\"release value\""},
+            {Litr::CLI::TokenType::COMMAND, "build"},
+            {Litr::CLI::TokenType::COMMA, ","},
+            {Litr::CLI::TokenType::COMMAND, "run"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Long parameter with string values with whitespace") {
-    litr::cli::Scanner scanner{"  --target  = \"release\"  build ,run  "};
+    Litr::CLI::Scanner scanner{"  --target  = \"release\"  build ,run  "};
 
     constexpr int item_count{6};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::cli::TokenType::LONG_PARAMETER, "--target"},
-            {litr::cli::TokenType::EQUAL, "="},
-            {litr::cli::TokenType::STRING, "\"release\""},
-            {litr::cli::TokenType::COMMAND, "build"},
-            {litr::cli::TokenType::COMMA, ","},
-            {litr::cli::TokenType::COMMAND, "run"}}};
+        {{Litr::CLI::TokenType::LONG_PARAMETER, "--target"},
+            {Litr::CLI::TokenType::EQUAL, "="},
+            {Litr::CLI::TokenType::STRING, "\"release\""},
+            {Litr::CLI::TokenType::COMMAND, "build"},
+            {Litr::CLI::TokenType::COMMA, ","},
+            {Litr::CLI::TokenType::COMMAND, "run"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Short parameter with number values") {
-    litr::cli::Scanner scanner{" -t=42"};
+    Litr::CLI::Scanner scanner{" -t=42"};
 
-    std::array<TokenDefinition, 3> definition{{{litr::cli::TokenType::SHORT_PARAMETER, "-t"},
-        {litr::cli::TokenType::EQUAL, "="},
-        {litr::cli::TokenType::NUMBER, "42"}}};
+    std::array<TokenDefinition, 3> definition{{{Litr::CLI::TokenType::SHORT_PARAMETER, "-t"},
+        {Litr::CLI::TokenType::EQUAL, "="},
+        {Litr::CLI::TokenType::NUMBER, "42"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Mixed parameters with mixed values and whitespace") {
-    litr::cli::Scanner scanner{" -t=\"release\" --debug  -p = 2.45"};
+    Litr::CLI::Scanner scanner{" -t=\"release\" --debug  -p = 2.45"};
 
     constexpr int item_count{7};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::cli::TokenType::SHORT_PARAMETER, "-t"},
-            {litr::cli::TokenType::EQUAL, "="},
-            {litr::cli::TokenType::STRING, "\"release\""},
-            {litr::cli::TokenType::LONG_PARAMETER, "--debug"},
-            {litr::cli::TokenType::SHORT_PARAMETER, "-p"},
-            {litr::cli::TokenType::EQUAL, "="},
-            {litr::cli::TokenType::NUMBER, "2.45"}}};
+        {{Litr::CLI::TokenType::SHORT_PARAMETER, "-t"},
+            {Litr::CLI::TokenType::EQUAL, "="},
+            {Litr::CLI::TokenType::STRING, "\"release\""},
+            {Litr::CLI::TokenType::LONG_PARAMETER, "--debug"},
+            {Litr::CLI::TokenType::SHORT_PARAMETER, "-p"},
+            {Litr::CLI::TokenType::EQUAL, "="},
+            {Litr::CLI::TokenType::NUMBER, "2.45"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Mixed source string") {
-    litr::cli::Scanner scanner{"-t=\"release\" build, run --peer = 1.23"};
+    Litr::CLI::Scanner scanner{"-t=\"release\" build, run --peer = 1.23"};
 
     constexpr int item_count{9};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::cli::TokenType::SHORT_PARAMETER, "-t"},
-            {litr::cli::TokenType::EQUAL, "="},
-            {litr::cli::TokenType::STRING, "\"release\""},
-            {litr::cli::TokenType::COMMAND, "build"},
-            {litr::cli::TokenType::COMMA, ","},
-            {litr::cli::TokenType::COMMAND, "run"},
-            {litr::cli::TokenType::LONG_PARAMETER, "--peer"},
-            {litr::cli::TokenType::EQUAL, "="},
-            {litr::cli::TokenType::NUMBER, "1.23"}}};
+        {{Litr::CLI::TokenType::SHORT_PARAMETER, "-t"},
+            {Litr::CLI::TokenType::EQUAL, "="},
+            {Litr::CLI::TokenType::STRING, "\"release\""},
+            {Litr::CLI::TokenType::COMMAND, "build"},
+            {Litr::CLI::TokenType::COMMA, ","},
+            {Litr::CLI::TokenType::COMMAND, "run"},
+            {Litr::CLI::TokenType::LONG_PARAMETER, "--peer"},
+            {Litr::CLI::TokenType::EQUAL, "="},
+            {Litr::CLI::TokenType::NUMBER, "1.23"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Does not care about invalid semantics") {
-    litr::cli::Scanner scanner{", , ,"};
+    Litr::CLI::Scanner scanner{", , ,"};
 
     std::array<TokenDefinition, 3> definition{{
-        {litr::cli::TokenType::COMMA, ","},
-        {litr::cli::TokenType::COMMA, ","},
-        {litr::cli::TokenType::COMMA, ","},
+        {Litr::CLI::TokenType::COMMA, ","},
+        {Litr::CLI::TokenType::COMMA, ","},
+        {Litr::CLI::TokenType::COMMA, ","},
     }};
 
     CHECK_DEFINITION(scanner, definition);
@@ -201,32 +201,32 @@ TEST_SUITE("CLI::Scanner") {
 
   // Error cases
   TEST_CASE("Invalidates unterminated string syntax") {
-    litr::cli::Scanner scanner{"\"str"};
+    Litr::CLI::Scanner scanner{"\"str"};
 
     std::array<TokenDefinition, 1> definition{
-        {{litr::cli::TokenType::ERROR, "Unterminated string."}}};
+        {{Litr::CLI::TokenType::ERROR, "Unterminated string."}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Invalidates unknown characters, but does not stop scanning") {
-    litr::cli::Scanner scanner{"? -p"};
+    Litr::CLI::Scanner scanner{"? -p"};
 
     std::array<TokenDefinition, 2> definition{
-        {{litr::cli::TokenType::ERROR, "Unexpected character."},
-            {litr::cli::TokenType::SHORT_PARAMETER, "-p"}}};
+        {{Litr::CLI::TokenType::ERROR, "Unexpected character."},
+            {Litr::CLI::TokenType::SHORT_PARAMETER, "-p"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Invalidates wrong long parameter start character") {
-    litr::cli::Scanner scanner{"--1 --_bob"};
+    Litr::CLI::Scanner scanner{"--1 --_bob"};
 
     std::array<TokenDefinition, 2> definition{
-        {{litr::cli::TokenType::ERROR, "A parameter can only start with the characters A-Za-z."},
-            {litr::cli::TokenType::ERROR,
+        {{Litr::CLI::TokenType::ERROR, "A parameter can only start with the characters A-Za-z."},
+            {Litr::CLI::TokenType::ERROR,
                 "A parameter can only start with the characters A-Za-z."}}};
 
     CHECK_DEFINITION(scanner, definition);
@@ -234,21 +234,21 @@ TEST_SUITE("CLI::Scanner") {
   }
 
   TEST_CASE("Invalidates wrong short parameter name") {
-    litr::cli::Scanner scanner{"-1 -_ -?"};
+    Litr::CLI::Scanner scanner{"-1 -_ -?"};
 
     std::array<TokenDefinition, 3> definition{
-        {{litr::cli::TokenType::ERROR, "A short parameter can only be A-Za-z as name."},
-            {litr::cli::TokenType::ERROR, "A short parameter can only be A-Za-z as name."},
-            {litr::cli::TokenType::ERROR, "A short parameter can only be A-Za-z as name."}}};
+        {{Litr::CLI::TokenType::ERROR, "A short parameter can only be A-Za-z as name."},
+            {Litr::CLI::TokenType::ERROR, "A short parameter can only be A-Za-z as name."},
+            {Litr::CLI::TokenType::ERROR, "A short parameter can only be A-Za-z as name."}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Invalidates too long short parameter name") {
-    litr::cli::Scanner scanner{"-long"};
+    Litr::CLI::Scanner scanner{"-long"};
 
-    std::array<TokenDefinition, 1> definition{{{litr::cli::TokenType::ERROR,
+    std::array<TokenDefinition, 1> definition{{{Litr::CLI::TokenType::ERROR,
         "A short parameter can only contain one character (A-Za-z)."}}};
 
     CHECK_DEFINITION(scanner, definition);
@@ -256,10 +256,10 @@ TEST_SUITE("CLI::Scanner") {
   }
 
   TEST_CASE("Invalidates duplicated parameter initializer") {
-    litr::cli::Scanner scanner{"---long"};
+    Litr::CLI::Scanner scanner{"---long"};
 
     std::array<TokenDefinition, 1> definition{
-        {{litr::cli::TokenType::ERROR, "A parameter can only start with the characters A-Za-z."}}};
+        {{Litr::CLI::TokenType::ERROR, "A parameter can only start with the characters A-Za-z."}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);

--- a/src/tests/Tests/Core/CMakeLists.txt
+++ b/src/tests/Tests/Core/CMakeLists.txt
@@ -2,46 +2,46 @@
 
 add_executable(Config_Loader Config/Loader.int.cpp $<TARGET_OBJECTS:Tests>)
 add_test(NAME Config_Loader COMMAND Config_Loader)
-target_link_libraries(Config_Loader PRIVATE TestBase Core)
+target_link_libraries(Config_Loader PRIVATE TestBase)
 
 add_executable(Config_FileResolver Config/FileResolver.unit.cpp $<TARGET_OBJECTS:Tests>)
 add_test(NAME Config_FileResolver COMMAND Config_FileResolver)
-target_link_libraries(Config_FileResolver PRIVATE TestBase Core)
+target_link_libraries(Config_FileResolver PRIVATE TestBase)
 
 add_executable(Config_CommandBuilder Config/CommandBuilder.unit.cpp $<TARGET_OBJECTS:Tests>)
 add_test(NAME Config_CommandBuilder COMMAND Config_CommandBuilder)
-target_link_libraries(Config_CommandBuilder PRIVATE TestBase Core)
+target_link_libraries(Config_CommandBuilder PRIVATE TestBase)
 
 add_executable(Config_ParameterBuilder Config/ParameterBuilder.unit.cpp $<TARGET_OBJECTS:Tests>)
 add_test(NAME Config_ParameterBuilder COMMAND Config_ParameterBuilder)
-target_link_libraries(Config_ParameterBuilder PRIVATE TestBase Core)
+target_link_libraries(Config_ParameterBuilder PRIVATE TestBase)
 
 add_executable(Config_Query Config/Query.int.cpp $<TARGET_OBJECTS:Tests>)
 add_test(NAME Config_Query COMMAND Config_Query)
-target_link_libraries(Config_Query PRIVATE TestBase Core)
+target_link_libraries(Config_Query PRIVATE TestBase)
 
 # --- CLI ---
 
 add_executable(CLI_Scanner CLI/Scanner.unit.cpp $<TARGET_OBJECTS:Tests>)
 add_test(NAME CLI_Scanner COMMAND CLI_Scanner)
-target_link_libraries(CLI_Scanner PRIVATE TestBase Core)
+target_link_libraries(CLI_Scanner PRIVATE TestBase)
 
 add_executable(CLI_Parser CLI/Parser.unit.cpp $<TARGET_OBJECTS:Tests>)
 add_test(NAME CLI_Parser COMMAND CLI_Parser)
-target_link_libraries(CLI_Parser PRIVATE TestBase Core)
+target_link_libraries(CLI_Parser PRIVATE TestBase)
 
 # --- Script ---
 
 add_executable(Script_Scanner Script/Scanner.unit.cpp $<TARGET_OBJECTS:Tests>)
 add_test(NAME Script_Scanner COMMAND Script_Scanner)
-target_link_libraries(Script_Scanner PRIVATE TestBase Core)
+target_link_libraries(Script_Scanner PRIVATE TestBase)
 
 add_executable(Script_Compiler Script/Compiler.unit.cpp $<TARGET_OBJECTS:Tests>)
 add_test(NAME Script_Compiler COMMAND Script_Compiler)
-target_link_libraries(Script_Compiler PRIVATE TestBase Core)
+target_link_libraries(Script_Compiler PRIVATE TestBase)
 
 # --- Misc ---
 
 add_executable(Misc_Utils Utils.unit.cpp $<TARGET_OBJECTS:Tests>)
 add_test(NAME Misc_Utils COMMAND Misc_Utils)
-target_link_libraries(Misc_Utils PRIVATE TestBase Core)
+target_link_libraries(Misc_Utils PRIVATE TestBase)

--- a/src/tests/Tests/Core/Config/CommandBuilder.unit.cpp
+++ b/src/tests/Tests/Core/Config/CommandBuilder.unit.cpp
@@ -13,29 +13,29 @@ TEST_SUITE("Config::CommandBuilder") {
   TEST_CASE("Initiates a Command on construction") {
     const auto [context, data] = create_toml_mock("test", "");
 
-    litr::config::CommandBuilder builder{context, data, "test"};
-    litr::config::Command builder_result{*builder.get_result()};
-    litr::config::Command compare{"test"};
+    Litr::Config::CommandBuilder builder{context, data, "test"};
+    Litr::Config::Command builder_result{*builder.get_result()};
+    Litr::Config::Command compare{"test"};
 
-    CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+    CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
     CHECK_EQ(sizeof(builder_result), sizeof(compare));
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("CommandBuilder::add_script_line") {
     SUBCASE("Can add multiple lines of script to the command") {
       const auto [context, data] = create_toml_mock("test", "");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_script_line("first line");
       builder.add_script_line("second line");
 
       const auto result{builder.get_result()};
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(result->script[0], "first line");
       CHECK_EQ(result->script[1], "second line");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
   }
 
@@ -43,78 +43,78 @@ TEST_SUITE("Config::CommandBuilder") {
     SUBCASE("Can override the whole script at once") {
       const auto [context, data] = create_toml_mock("test", "");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       const std::vector script{"first line", "second line"};
       builder.add_script(script);
 
       const auto result{builder.get_result()};
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(result->script[0], "first line");
       CHECK_EQ(result->script[1], "second line");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits and error if script data is not of type string") {
       const auto [context, data] = create_toml_mock("test", "scripts = [1]");
 
-      litr::config::TomlFileAdapter file{};
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::TomlFileAdapter file{};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_script(file.find(data, "scripts"));
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           "A command script can be either a string or array of strings.");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits only one error if script data is not of type string") {
       const auto [context, data] = create_toml_mock("test", "scripts = [1, 2, 3]");
 
-      litr::config::TomlFileAdapter file{};
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::TomlFileAdapter file{};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_script(file.find(data, "scripts"));
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           "A command script can be either a string or array of strings.");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Writes scripts from TOML data successfully") {
       const auto [context, data] =
           create_toml_mock("test", R"(scripts = ["first line", "second line"])");
 
-      litr::config::TomlFileAdapter file{};
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::TomlFileAdapter file{};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_script(file.find(data, "scripts"));
 
       const auto result{builder.get_result()};
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(result->script[0], "first line");
       CHECK_EQ(result->script[1], "second line");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Retains locations information") {
       const auto [context, data] =
           create_toml_mock("test", R"(scripts = ["first line", "second line"])");
 
-      litr::config::TomlFileAdapter file{};
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::TomlFileAdapter file{};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_script(file.find(data, "scripts"));
 
       const auto result{builder.get_result()};
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(result->Locations[0].line, 1);
       CHECK_EQ(result->Locations[0].column, 12);
       CHECK_EQ(result->Locations[0].line_str, R"(scripts = ["first line", "second line"])");
       CHECK_EQ(result->Locations[1].line, 1);
       CHECK_EQ(result->Locations[1].column, 26);
       CHECK_EQ(result->Locations[1].line_str, R"(scripts = ["first line", "second line"])");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
   }
 
@@ -122,35 +122,35 @@ TEST_SUITE("Config::CommandBuilder") {
     SUBCASE("Does nothing if description is not set") {
       const auto [context, data] = create_toml_mock("test", R"(key = "value")");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_description();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK(builder.get_result()->description.empty());
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits and error if description is not a string") {
       const auto [context, data] = create_toml_mock("test", R"(description = 42)");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_description();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(The "description" can only be a string.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Extracts the description from toml data") {
       const auto [context, data] = create_toml_mock("test", R"(description = "Text")");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_description();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(builder.get_result()->description, "Text");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
   }
 
@@ -158,35 +158,35 @@ TEST_SUITE("Config::CommandBuilder") {
     SUBCASE("Does nothing if example is not set") {
       const auto [context, data] = create_toml_mock("test", R"(key = "value")");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_example();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK(builder.get_result()->example.empty());
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits and error if example is not a string") {
       const auto [context, data] = create_toml_mock("test", R"(example = 42)");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_example();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
       CHECK_EQ(
-          litr::error::Handler::get_errors()[0].message, R"(The "example" can only be a string.)");
-      litr::error::Handler::flush();
+          Litr::Error::Handler::get_errors()[0].message, R"(The "example" can only be a string.)");
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Extracts the example from toml data") {
       const auto [context, data] = create_toml_mock("test", R"(example = "Text")");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_example();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(builder.get_result()->example, "Text");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
   }
 
@@ -194,73 +194,73 @@ TEST_SUITE("Config::CommandBuilder") {
     SUBCASE("Does nothing if dir is not set") {
       const auto [context, data] = create_toml_mock("test", R"(key = "value")");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
-      builder.add_directory(litr::Path(""));
+      Litr::Config::CommandBuilder builder{context, data, "test"};
+      builder.add_directory(Litr::Path(""));
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK(builder.get_result()->directory.empty());
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if dir is not a string or array of strings") {
       const auto [context, data] = create_toml_mock("test", R"(dir = 42)");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
-      builder.add_directory(litr::Path(""));
+      Litr::Config::CommandBuilder builder{context, data, "test"};
+      builder.add_directory(Litr::Path(""));
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(A "dir" can either be a string or array of strings.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if dir array does not only contain strings") {
       const auto [context, data] = create_toml_mock("test", R"(dir = [1])");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
-      builder.add_directory(litr::Path(""));
+      Litr::Config::CommandBuilder builder{context, data, "test"};
+      builder.add_directory(Litr::Path(""));
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(A "dir" can either be a string or array of strings.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits more than one error if dir array does not only contain multiple strings") {
       const auto [context, data] = create_toml_mock("test", R"(dir = [1, 2])");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
-      builder.add_directory(litr::Path(""));
+      Litr::Config::CommandBuilder builder{context, data, "test"};
+      builder.add_directory(Litr::Path(""));
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 2);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 2);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(A "dir" can either be a string or array of strings.)");
-      CHECK_EQ(litr::error::Handler::get_errors()[1].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors()[1].message,
           R"(A "dir" can either be a string or array of strings.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Creates a directory folder from a string") {
       const auto [context, data] = create_toml_mock("test", R"(dir = ["folder1"])");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
-      builder.add_directory(litr::Path(""));
+      Litr::Config::CommandBuilder builder{context, data, "test"};
+      builder.add_directory(Litr::Path(""));
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(builder.get_result()->directory[0], "folder1");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Creates a directory folder from an array of strings") {
       const auto [context, data] = create_toml_mock("test", R"(dir = ["folder1", "folder2"])");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
-      builder.add_directory(litr::Path(""));
+      Litr::Config::CommandBuilder builder{context, data, "test"};
+      builder.add_directory(Litr::Path(""));
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(builder.get_result()->directory[0], "folder1");
       CHECK_EQ(builder.get_result()->directory[1], "folder2");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
   }
 
@@ -268,46 +268,46 @@ TEST_SUITE("Config::CommandBuilder") {
     SUBCASE("Does nothing if output is not set") {
       const auto [context, data] = create_toml_mock("test", R"(key = "value")");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_output();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
-      CHECK_EQ(builder.get_result()->output, litr::config::Command::Output::UNCHANGED);
-      litr::error::Handler::flush();
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
+      CHECK_EQ(builder.get_result()->output, Litr::Config::Command::Output::UNCHANGED);
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if output type is not known") {
       const auto [context, data] = create_toml_mock("test", R"(output = "unknown")");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_output();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(The "output" can either be "unchanged" or "silent".)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Sets the output to silent if the option is provided") {
       const auto [context, data] = create_toml_mock("test", R"(output = "silent")");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_output();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
-      CHECK_EQ(builder.get_result()->output, litr::config::Command::Output::SILENT);
-      litr::error::Handler::flush();
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
+      CHECK_EQ(builder.get_result()->output, Litr::Config::Command::Output::SILENT);
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Sets the output to unchanged if the option is provided") {
       const auto [context, data] = create_toml_mock("test", R"(output = "unchanged")");
 
-      litr::config::CommandBuilder builder{context, data, "test"};
+      Litr::Config::CommandBuilder builder{context, data, "test"};
       builder.add_output();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
-      CHECK_EQ(builder.get_result()->output, litr::config::Command::Output::UNCHANGED);
-      litr::error::Handler::flush();
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
+      CHECK_EQ(builder.get_result()->output, Litr::Config::Command::Output::UNCHANGED);
+      Litr::Error::Handler::flush();
     }
   }
 
@@ -315,14 +315,14 @@ TEST_SUITE("Config::CommandBuilder") {
     SUBCASE("Sets a child command as reference") {
       const auto [context, data] = create_toml_mock("test", "");
 
-      litr::config::CommandBuilder builder_root{context, data, "test"};
-      litr::config::CommandBuilder builder_child{context, data, "test"};
+      Litr::Config::CommandBuilder builder_root{context, data, "test"};
+      Litr::Config::CommandBuilder builder_child{context, data, "test"};
 
       builder_root.add_child_command(builder_child.get_result());
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(builder_root.get_result()->child_commands.size(), 1);
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
   }
 }

--- a/src/tests/Tests/Core/Config/CommandBuilder.unit.cpp
+++ b/src/tests/Tests/Core/Config/CommandBuilder.unit.cpp
@@ -60,7 +60,7 @@ TEST_SUITE("Config::CommandBuilder") {
 
       litr::config::TomlFileAdapter file{};
       litr::config::CommandBuilder builder{context, data, "test"};
-      builder.add_script(file.find_value(data, "scripts"));
+      builder.add_script(file.find(data, "scripts"));
 
       CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
       CHECK_EQ(litr::error::Handler::get_errors()[0].message,
@@ -73,7 +73,7 @@ TEST_SUITE("Config::CommandBuilder") {
 
       litr::config::TomlFileAdapter file{};
       litr::config::CommandBuilder builder{context, data, "test"};
-      builder.add_script(file.find_value(data, "scripts"));
+      builder.add_script(file.find(data, "scripts"));
 
       CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
       CHECK_EQ(litr::error::Handler::get_errors()[0].message,
@@ -87,7 +87,7 @@ TEST_SUITE("Config::CommandBuilder") {
 
       litr::config::TomlFileAdapter file{};
       litr::config::CommandBuilder builder{context, data, "test"};
-      builder.add_script(file.find_value(data, "scripts"));
+      builder.add_script(file.find(data, "scripts"));
 
       const auto result{builder.get_result()};
 
@@ -103,7 +103,7 @@ TEST_SUITE("Config::CommandBuilder") {
 
       litr::config::TomlFileAdapter file{};
       litr::config::CommandBuilder builder{context, data, "test"};
-      builder.add_script(file.find_value(data, "scripts"));
+      builder.add_script(file.find(data, "scripts"));
 
       const auto result{builder.get_result()};
 

--- a/src/tests/Tests/Core/Config/FileResolver.unit.cpp
+++ b/src/tests/Tests/Core/Config/FileResolver.unit.cpp
@@ -10,8 +10,8 @@ TEST_SUITE("Config::FileResolver") {
   TEST_CASE("File not found" * doctest::skip()) {
     // @todo: This will find a potential config in home of the executing system.
     // So mocking would be solution, maybe.
-    litr::config::FileResolver config{"/some/path/to/nowhere"};
-    CHECK_EQ(config.get_status(), litr::config::FileResolver::Status::NOT_FOUND);
+    Litr::Config::FileResolver config{"/some/path/to/nowhere"};
+    CHECK_EQ(config.get_status(), Litr::Config::FileResolver::Status::NOT_FOUND);
     CHECK_EQ(config.get_file_path(), "");
   }
 }

--- a/src/tests/Tests/Core/Config/Loader.int.cpp
+++ b/src/tests/Tests/Core/Config/Loader.int.cpp
@@ -199,8 +199,8 @@ TEST_SUITE("Config::Loader") {
 
     CHECK(litr::error::Handler::has_errors());
     CHECK_EQ(errors.size(), 2);
-    CHECK_EQ(errors[0].message, R"(The parameter name "h" is reserved by Litr.)");
-    CHECK_EQ(errors[1].message, R"(The parameter name "help" is reserved by Litr.)");
+    CHECK_EQ(errors[0].message, R"(The parameter name "help" is reserved by Litr.)");
+    CHECK_EQ(errors[1].message, R"(The parameter name "h" is reserved by Litr.)");
     litr::error::Handler::flush();
   }
 

--- a/src/tests/Tests/Core/Config/Loader.int.cpp
+++ b/src/tests/Tests/Core/Config/Loader.int.cpp
@@ -14,113 +14,113 @@
 
 TEST_SUITE("Config::Loader") {
   TEST_CASE("Loads a config file without issues") {
-    const litr::Path path{"../../Fixtures/Config/empty.toml"};
-    const litr::config::Loader config{path};
+    const Litr::Path path{"../../Fixtures/Config/empty.toml"};
+    const Litr::Config::Loader config{path};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
-    litr::error::Handler::flush();
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Emits a custom syntax error on exception") {
-    const litr::Path path{"../../Fixtures/Config/syntax-error.toml"};
-    const litr::config::Loader config{path};
-    const auto errors{litr::error::Handler::get_errors()};
+    const Litr::Path path{"../../Fixtures/Config/syntax-error.toml"};
+    const Litr::Config::Loader config{path};
+    const auto errors{Litr::Error::Handler::get_errors()};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "There is a syntax error inside the configuration file.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Emits an error on malformed command") {
-    const litr::Path path{"../../Fixtures/Config/malformed-command.toml"};
-    const litr::config::Loader config{path};
-    const auto errors{litr::error::Handler::get_errors()};
+    const Litr::Path path{"../../Fixtures/Config/malformed-command.toml"};
+    const Litr::Config::Loader config{path};
+    const auto errors{Litr::Error::Handler::get_errors()};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "A command can be a string or table.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Emits an error if command script is not a string") {
-    const litr::Path path{"../../Fixtures/Config/malformed-command-script.toml"};
-    const litr::config::Loader config{path};
-    const auto errors{litr::error::Handler::get_errors()};
+    const Litr::Path path{"../../Fixtures/Config/malformed-command-script.toml"};
+    const Litr::Config::Loader config{path};
+    const auto errors{Litr::Error::Handler::get_errors()};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "A command script can be either a string or array of strings.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Emits an error if command property unknown") {
-    const litr::Path path{"../../Fixtures/Config/unknown-command-property.toml"};
-    const litr::config::Loader config{path};
-    const auto errors{litr::error::Handler::get_errors()};
+    const Litr::Path path{"../../Fixtures/Config/unknown-command-property.toml"};
+    const Litr::Config::Loader config{path};
+    const auto errors{Litr::Error::Handler::get_errors()};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message,
         R"(The command property "unknown" does not exist. Please refer to the docs.)");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Copies errors from CommandBuilder to Loader on malformed script array") {
-    const litr::Path path{"../../Fixtures/Config/command-script-array-malformed.toml"};
-    const litr::config::Loader config{path};
-    const auto errors{litr::error::Handler::get_errors()};
+    const Litr::Path path{"../../Fixtures/Config/command-script-array-malformed.toml"};
+    const Litr::Config::Loader config{path};
+    const auto errors{Litr::Error::Handler::get_errors()};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "A command script can be either a string or array of strings.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Copies errors from CommandBuilder to Loader on detailed malformed script array") {
-    const litr::Path path{"../../Fixtures/Config/command-detailed-script-array-malformed.toml"};
-    const litr::config::Loader config{path};
-    const auto errors{litr::error::Handler::get_errors()};
+    const Litr::Path path{"../../Fixtures/Config/command-detailed-script-array-malformed.toml"};
+    const Litr::Config::Loader config{path};
+    const auto errors{Litr::Error::Handler::get_errors()};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "A command script can be either a string or array of strings.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Copies errors from CommandBuilder to Loader on multiple malformed fields") {
-    const litr::Path path{"../../Fixtures/Config/command-description-and-output-malformed.toml"};
-    const litr::config::Loader config{path};
-    const auto errors{litr::error::Handler::get_errors()};
+    const Litr::Path path{"../../Fixtures/Config/command-description-and-output-malformed.toml"};
+    const Litr::Config::Loader config{path};
+    const auto errors{Litr::Error::Handler::get_errors()};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
     CHECK_EQ(errors.size(), 2);
     CHECK_EQ(errors[0].message, R"(The "description" can only be a string.)");
     CHECK_EQ(errors[1].message, R"(The "output" can either be "unchanged" or "silent".)");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Does nothing if no commands or parameters defined") {
-    const litr::Path path{"../../Fixtures/Config/empty-commands-params.toml"};
-    const litr::config::Loader config{path};
+    const Litr::Path path{"../../Fixtures/Config/empty-commands-params.toml"};
+    const Litr::Config::Loader config{path};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(config.get_commands().size(), 0);
     CHECK_EQ(config.get_parameters().size(), 0);
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Loads commands") {
-    const litr::Path path{"../../Fixtures/Config/commands-params.toml"};
-    const auto config{std::make_shared<litr::config::Loader>(path)};
+    const Litr::Path path{"../../Fixtures/Config/commands-params.toml"};
+    const auto config{std::make_shared<Litr::Config::Loader>(path)};
 
     SUBCASE("Successfully without errors") {
-      CHECK_FALSE(litr::error::Handler::has_errors());
+      CHECK_FALSE(Litr::Error::Handler::has_errors());
       CHECK_EQ(config->get_commands().size(), 3);
     }
 
     SUBCASE("Resolves all fields on a command") {
-      const litr::config::Query query{config};
+      const Litr::Config::Query query{config};
       const auto command{query.get_command("run")};
 
       CHECK_EQ(command->name, "run");
@@ -128,14 +128,14 @@ TEST_SUITE("Config::Loader") {
       CHECK_EQ(command->script[0], "Script");
       CHECK_EQ(command->description, "Description");
       CHECK_EQ(command->example, "Example");
-      CHECK_EQ(command->output, litr::config::Command::Output::SILENT);
+      CHECK_EQ(command->output, Litr::Config::Command::Output::SILENT);
       CHECK_EQ(command->directory.size(), 1);
       CHECK_EQ(command->directory[0], "../../Fixtures/Config/Directory");
       CHECK_EQ(command->child_commands.size(), 4);
     }
 
     SUBCASE("Resolves all fields on a command without sub commands") {
-      const litr::config::Query query{config};
+      const Litr::Config::Query query{config};
       const auto command{query.get_command("update")};
 
       CHECK_EQ(command->name, "update");
@@ -143,13 +143,13 @@ TEST_SUITE("Config::Loader") {
       CHECK_EQ(command->script[0], "git pull && git submodule update --init");
       CHECK(command->description.empty());
       CHECK(command->example.empty());
-      CHECK_EQ(command->output, litr::config::Command::Output::UNCHANGED);
+      CHECK_EQ(command->output, Litr::Config::Command::Output::UNCHANGED);
       CHECK(command->directory.empty());
       CHECK(command->child_commands.empty());
     }
 
     SUBCASE("Resolves all fields on a sub command") {
-      const litr::config::Query query{config};
+      const Litr::Config::Query query{config};
       const auto command1{query.get_command("run.first")};
       const auto command2{query.get_command("run.second")};
       const auto command3{query.get_command("run.third")};
@@ -182,7 +182,7 @@ TEST_SUITE("Config::Loader") {
     }
 
     SUBCASE("Resolves a very deep nested script") {
-      const litr::config::Query query{config};
+      const Litr::Config::Query query{config};
       const auto command{query.get_command("run.fourth.l1.l2.l3")};
 
       CHECK_NE(command, nullptr);
@@ -193,59 +193,59 @@ TEST_SUITE("Config::Loader") {
   }
 
   TEST_CASE("Emits an error if parameter name is reserved for Litr") {
-    const litr::Path path{"../../Fixtures/Config/reserved-parameter.toml"};
-    const litr::config::Loader config{path};
-    const auto errors{litr::error::Handler::get_errors()};
+    const Litr::Path path{"../../Fixtures/Config/reserved-parameter.toml"};
+    const Litr::Config::Loader config{path};
+    const auto errors{Litr::Error::Handler::get_errors()};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
     CHECK_EQ(errors.size(), 2);
     CHECK_EQ(errors[0].message, R"(The parameter name "help" is reserved by Litr.)");
     CHECK_EQ(errors[1].message, R"(The parameter name "h" is reserved by Litr.)");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Emits an error if parameter definition is malformed") {
-    const litr::Path path{"../../Fixtures/Config/malformed-parameter.toml"};
-    const litr::config::Loader config{path};
-    const auto errors{litr::error::Handler::get_errors()};
+    const Litr::Path path{"../../Fixtures/Config/malformed-parameter.toml"};
+    const Litr::Config::Loader config{path};
+    const auto errors{Litr::Error::Handler::get_errors()};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "A parameter needs to be a string or table.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Copies errors from ParameterBuilder to Loader on multiple malformed params") {
-    const litr::Path path{"../../Fixtures/Config/params-description-and-type-malformed.toml"};
-    const litr::config::Loader config{path};
-    const auto errors{litr::error::Handler::get_errors()};
+    const Litr::Path path{"../../Fixtures/Config/params-description-and-type-malformed.toml"};
+    const Litr::Config::Loader config{path};
+    const auto errors{Litr::Error::Handler::get_errors()};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
     CHECK_EQ(errors.size(), 2);
     CHECK_EQ(errors[0].message, R"(The "description" can only be a string.)");
     CHECK_EQ(
         errors[1].message, R"(A "type" can only be "string" or an array of options as strings.)");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Loads Parameters") {
-    const litr::Path path{"../../Fixtures/Config/commands-params.toml"};
-    const auto config{std::make_shared<litr::config::Loader>(path)};
+    const Litr::Path path{"../../Fixtures/Config/commands-params.toml"};
+    const auto config{std::make_shared<Litr::Config::Loader>(path)};
 
     SUBCASE("Successfully without errors") {
-      CHECK_FALSE(litr::error::Handler::has_errors());
+      CHECK_FALSE(Litr::Error::Handler::has_errors());
       CHECK_EQ(config->get_parameters().size(), 2);
     }
 
     SUBCASE("Resolves all fields on a parameter") {
-      const litr::config::Query query{config};
+      const Litr::Config::Query query{config};
       const auto param{query.get_parameter("target")};
 
       CHECK_EQ(param->name, "target");
       CHECK_EQ(param->description, "Description");
       CHECK_EQ(param->shortcut, "t");
       CHECK_EQ(param->default_value, "debug");
-      CHECK_EQ(param->type, litr::config::Parameter::Type::ARRAY);
+      CHECK_EQ(param->type, Litr::Config::Parameter::Type::ARRAY);
       CHECK_EQ(param->type_arguments.size(), 2);
       CHECK_EQ(param->type_arguments[0], "debug");
       CHECK_EQ(param->type_arguments[1], "release");

--- a/src/tests/Tests/Core/Config/ParameterBuilder.unit.cpp
+++ b/src/tests/Tests/Core/Config/ParameterBuilder.unit.cpp
@@ -13,60 +13,60 @@ TEST_SUITE("ParameterBuilder") {
   TEST_CASE("Initiates a Parameter on construction") {
     const auto [file, data] = create_toml_mock("test", "");
 
-    litr::config::ParameterBuilder builder{file, data, "test"};
-    litr::config::Parameter builder_result{*builder.get_result()};
-    litr::config::Parameter compare{"test"};
+    Litr::Config::ParameterBuilder builder{file, data, "test"};
+    Litr::Config::Parameter builder_result{*builder.get_result()};
+    Litr::Config::Parameter compare{"test"};
 
-    CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+    CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
     CHECK_EQ(sizeof(builder_result), sizeof(compare));
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("ParameterBuilder::add_description") {
     SUBCASE("Emits an error if add_description called without description field") {
       const auto [file, data] = create_toml_mock("test", R"(key = "value")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_description();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(You're missing the "description" field.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if description is not a string") {
       const auto [file, data] = create_toml_mock("test", "description = 42");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_description();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(The "description" can only be a string.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Extracts a description from toml data") {
       const auto [file, data] = create_toml_mock("test", R"(description = "Text")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_description();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(builder.get_result()->description, "Text");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Applies a description directly from a string") {
       const auto [file, data] = create_toml_mock("test", "");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_description("Text");
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(builder.get_result()->description, "Text");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
   }
 
@@ -74,74 +74,74 @@ TEST_SUITE("ParameterBuilder") {
     SUBCASE("Does nothing if no shortcut is not set") {
       const auto [file, data] = create_toml_mock("test", R"(key = "value")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_shortcut();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK(builder.get_result()->shortcut.empty());
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if shortcut is not a string") {
       const auto [file, data] = create_toml_mock("test", "shortcut = 42");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_shortcut();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
       CHECK_EQ(
-          litr::error::Handler::get_errors()[0].message, R"(A "shortcut" can only be a string.)");
-      litr::error::Handler::flush();
+          Litr::Error::Handler::get_errors()[0].message, R"(A "shortcut" can only be a string.)");
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if shortcut is reserved word 'help'") {
       const auto [file, data] = create_toml_mock("test", R"(shortcut = "help")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_shortcut();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(The shortcut name "help" is reserved by Litr.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if shortcut is reserved word 'h'") {
       const auto [file, data] = create_toml_mock("test", R"(shortcut = "h")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_shortcut();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(The shortcut name "h" is reserved by Litr.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Extracts the shortcut from toml data") {
       const auto [file, data] = create_toml_mock("test", R"(shortcut = "t")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_shortcut();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(builder.get_result()->shortcut, "t");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if shortcut is already defined") {
       const auto [file, data] = create_toml_mock("test", R"(shortcut = "x")");
-      auto param{std::make_shared<litr::config::Parameter>("something")};
+      auto param{std::make_shared<Litr::Config::Parameter>("something")};
       param->shortcut = "x";
-      std::vector<std::shared_ptr<litr::config::Parameter>> params{{param}};
+      std::vector<std::shared_ptr<Litr::Config::Parameter>> params{{param}};
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_shortcut(params);
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(The shortcut name "x" is already used for parameter "something".)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
   }
 
@@ -149,84 +149,84 @@ TEST_SUITE("ParameterBuilder") {
     SUBCASE("Does nothing if no type is not set") {
       const auto [file, data] = create_toml_mock("test", R"(key = "value")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_type();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
-      CHECK_EQ(builder.get_result()->type, litr::config::Parameter::Type::STRING);
-      litr::error::Handler::flush();
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
+      CHECK_EQ(builder.get_result()->type, Litr::Config::Parameter::Type::STRING);
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if string is set with an unknown option") {
       const auto [file, data] = create_toml_mock("test", R"(type = "unknown")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_type();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(The "type" option as string can only be "string" or "boolean". Provided value "unknown" is not known.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Sets the type successfully to String if options is string") {
       const auto [file, data] = create_toml_mock("test", R"(type = "string")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_type();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
-      CHECK_EQ(builder.get_result()->type, litr::config::Parameter::Type::STRING);
-      litr::error::Handler::flush();
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
+      CHECK_EQ(builder.get_result()->type, Litr::Config::Parameter::Type::STRING);
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Sets the type to Array on empty arrays") {
       const auto [file, data] = create_toml_mock("test", R"(type = [])");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_type();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
-      CHECK_EQ(builder.get_result()->type, litr::config::Parameter::Type::ARRAY);
-      litr::error::Handler::flush();
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
+      CHECK_EQ(builder.get_result()->type, Litr::Config::Parameter::Type::ARRAY);
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if a non string value is contained in the type array") {
       const auto [file, data] = create_toml_mock("test", R"(type = ["1", 2, "3"])");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_type();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(The options provided in "type" are not all strings.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Sets the type to Array with and populates TypeArguments") {
       const auto [file, data] = create_toml_mock("test", R"(type = ["test", "debug"])");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_type();
-      std::shared_ptr<litr::config::Parameter> result{builder.get_result()};
+      std::shared_ptr<Litr::Config::Parameter> result{builder.get_result()};
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
-      CHECK_EQ(result->type, litr::config::Parameter::Type::ARRAY);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
+      CHECK_EQ(result->type, Litr::Config::Parameter::Type::ARRAY);
       CHECK_EQ(result->type_arguments[0], "test");
       CHECK_EQ(result->type_arguments[1], "debug");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if type is neither a string nor an array") {
       const auto [file, data] = create_toml_mock("test", R"(type = 32)");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_type();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(A "type" can only be "string" or an array of options as strings.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
   }
 
@@ -234,62 +234,62 @@ TEST_SUITE("ParameterBuilder") {
     SUBCASE("Does nothing if default is not set") {
       const auto [file, data] = create_toml_mock("test", R"(key = "value")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_default();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK(builder.get_result()->default_value.empty());
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if default is not a string") {
       const auto [file, data] = create_toml_mock("test", R"(default = 1)");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_default();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(The field "default" needs to be a string.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Emits an error if default value is not found inside type array") {
       const auto [file, data] = create_toml_mock("test", R"(type = ["Not default"]
 default = "Default")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_type();
       builder.add_default();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 1);
-      CHECK_EQ(litr::error::Handler::get_errors()[0].message,
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 1);
+      CHECK_EQ(Litr::Error::Handler::get_errors()[0].message,
           R"(Cannot find default value "Default" inside "type" list defined in line 1.)");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Sets default if defined as string") {
       const auto [file, data] = create_toml_mock("test", R"(default = "something")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_default();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(builder.get_result()->default_value, "something");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
 
     SUBCASE("Sets default if defined as string and type array contains value") {
       const auto [file, data] = create_toml_mock("test", R"(type = ["something"]
 default = "something")");
 
-      litr::config::ParameterBuilder builder{file, data, "test"};
+      Litr::Config::ParameterBuilder builder{file, data, "test"};
       builder.add_type();
       builder.add_default();
 
-      CHECK_EQ(litr::error::Handler::get_errors().size(), 0);
+      CHECK_EQ(Litr::Error::Handler::get_errors().size(), 0);
       CHECK_EQ(builder.get_result()->default_value, "something");
-      litr::error::Handler::flush();
+      Litr::Error::Handler::flush();
     }
   }
 }

--- a/src/tests/Tests/Core/Config/Query.int.cpp
+++ b/src/tests/Tests/Core/Config/Query.int.cpp
@@ -10,9 +10,9 @@
 
 TEST_SUITE("Config::Query") {
   TEST_CASE("get_command()") {
-    const litr::Path path{"../../Fixtures/Config/commands-params.toml"};
-    const auto config{std::make_shared<litr::config::Loader>(path)};
-    const litr::config::Query query{config};
+    const Litr::Path path{"../../Fixtures/Config/commands-params.toml"};
+    const auto config{std::make_shared<Litr::Config::Loader>(path)};
+    const Litr::Config::Query query{config};
 
     SUBCASE("Get top level command") {
       CHECK_EQ(query.get_command("run")->name, "run");
@@ -36,9 +36,9 @@ TEST_SUITE("Config::Query") {
   }
 
   TEST_CASE("get_commands()") {
-    const litr::Path path{"../../Fixtures/Config/commands-params.toml"};
-    const auto config{std::make_shared<litr::config::Loader>(path)};
-    const litr::config::Query query{config};
+    const Litr::Path path{"../../Fixtures/Config/commands-params.toml"};
+    const auto config{std::make_shared<Litr::Config::Loader>(path)};
+    const Litr::Config::Query query{config};
 
     SUBCASE("Get all defined commands") {
       CHECK_EQ(query.get_commands().size(), 3);
@@ -54,9 +54,9 @@ TEST_SUITE("Config::Query") {
   }
 
   TEST_CASE("get_parameter()") {
-    const litr::Path path{"../../Fixtures/Config/commands-params.toml"};
-    const auto config{std::make_shared<litr::config::Loader>(path)};
-    const litr::config::Query query{config};
+    const Litr::Path path{"../../Fixtures/Config/commands-params.toml"};
+    const auto config{std::make_shared<Litr::Config::Loader>(path)};
+    const Litr::Config::Query query{config};
 
     SUBCASE("Get parameter by name") {
       CHECK_EQ(query.get_parameter("target")->name, "target");
@@ -72,9 +72,9 @@ TEST_SUITE("Config::Query") {
   }
 
   TEST_CASE("get_parameters()") {
-    const litr::Path path{"../../Fixtures/Config/commands-params.toml"};
-    const auto config{std::make_shared<litr::config::Loader>(path)};
-    const litr::config::Query query{config};
+    const Litr::Path path{"../../Fixtures/Config/commands-params.toml"};
+    const auto config{std::make_shared<Litr::Config::Loader>(path)};
+    const Litr::Config::Query query{config};
 
     SUBCASE("Get all defined parameters") {
       CHECK_EQ(query.get_parameters().size(), 2);

--- a/src/tests/Tests/Core/Script/Compiler.unit.cpp
+++ b/src/tests/Tests/Core/Script/Compiler.unit.cpp
@@ -12,9 +12,9 @@
 #include "Core/Error/Handler.hpp"
 
 TEST_SUITE("script::Compiler") {
-  using Variables = litr::script::Compiler::Variables;
-  using Location = litr::config::Location;
-  using Compiler = litr::script::Compiler;
+  using Variables = Litr::Script::Compiler::Variables;
+  using Location = Litr::Config::Location;
+  using Compiler = Litr::Script::Compiler;
 
   // Success
   TEST_CASE("Single string") {
@@ -23,9 +23,9 @@ TEST_SUITE("script::Compiler") {
     Variables variables{};
     Compiler compiler{source, location, variables};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(compiler.get_script(), "echo 'Hello'");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Single string in the middle") {
@@ -34,99 +34,99 @@ TEST_SUITE("script::Compiler") {
     Variables variables{};
     Compiler compiler{source, location, variables};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(compiler.get_script(), "echo 'Hello' and more");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Single variable") {
     const std::string source{"echo '%{target}'"};
     Location location{1, 1, R"(script = "echo '%{target}'")"};
-    Variables variables{{{"target", litr::cli::Variable("target", std::string("Hello"))}}};
+    Variables variables{{{"target", Litr::CLI::Variable("target", std::string("Hello"))}}};
     Compiler compiler{source, location, variables};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(compiler.get_script(), "echo 'Hello'");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Single variable in the middle") {
     const std::string source{"echo '%{target}' and more"};
     Location location{1, 1, R"(script = "echo '%{target}' and more")"};
-    Variables variables{{{"target", litr::cli::Variable("target", std::string("Hello"))}}};
+    Variables variables{{{"target", Litr::CLI::Variable("target", std::string("Hello"))}}};
     Compiler compiler{source, location, variables};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(compiler.get_script(), "echo 'Hello' and more");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Single true boolean variable") {
     const std::string source{"echo %{target 'Hello'}"};
     Location location{1, 1, R"(script = "echo %{target 'Hello'}")"};
-    Variables variables{{{"target", litr::cli::Variable("target", true)}}};
+    Variables variables{{{"target", Litr::CLI::Variable("target", true)}}};
     Compiler compiler{source, location, variables};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(compiler.get_script(), "echo Hello");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Single false boolean variable") {
     const std::string source{"echo %{target 'Hello'}"};
     Location location{1, 1, R"(script = "echo %{target 'Hello'}")"};
-    Variables variables{{"target", litr::cli::Variable("target", false)}};
+    Variables variables{{"target", Litr::CLI::Variable("target", false)}};
     Compiler compiler{source, location, variables};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(compiler.get_script(), "echo ");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Boolean variable printing value of second variable") {
     const std::string source{"echo '%{target value}'"};
     Location location{1, 1, R"(script = "echo '%{target value}'")"};
-    Variables variables{{{"target", litr::cli::Variable("target", true)},
-        {"value", litr::cli::Variable("value", std::string("Hello"))}}};
+    Variables variables{{{"target", Litr::CLI::Variable("target", true)},
+        {"value", Litr::CLI::Variable("value", std::string("Hello"))}}};
     Compiler compiler{source, location, variables};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(compiler.get_script(), "echo 'Hello'");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Boolean variable not printing value of second variable") {
     const std::string source{"echo '%{target value}'"};
     Location location{1, 1, R"(script = "echo '%{target value}'")"};
-    Variables variables{{{"target", litr::cli::Variable("target", false)},
-        {"value", litr::cli::Variable("value", std::string("Hello"))}}};
+    Variables variables{{{"target", Litr::CLI::Variable("target", false)},
+        {"value", Litr::CLI::Variable("value", std::string("Hello"))}}};
     Compiler compiler{source, location, variables};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(compiler.get_script(), "echo ''");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Variable with true or-statement") {
     const std::string source{"echo %{target 'Hello' or 'Bye'}"};
     Location location{1, 1, R"(script = "echo %{target 'Hello' or 'Bye'}")"};
-    Variables variables{{{"target", litr::cli::Variable("target", true)}}};
+    Variables variables{{{"target", Litr::CLI::Variable("target", true)}}};
     Compiler compiler{source, location, variables};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(compiler.get_script(), "echo Hello");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Variable with false or-statement") {
     const std::string source{R"(echo %{target 'Hello' or 'Bye'})"};
     Location location{1, 1, R"(script = "echo %{target 'Hello' or 'Bye'}")"};
-    Variables variables{{{"target", litr::cli::Variable("target", false)}}};
+    Variables variables{{{"target", Litr::CLI::Variable("target", false)}}};
     Compiler compiler{source, location, variables};
 
-    CHECK_FALSE(litr::error::Handler::has_errors());
+    CHECK_FALSE(Litr::Error::Handler::has_errors());
     CHECK_EQ(compiler.get_script(), "echo Bye");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   // Error
@@ -137,72 +137,72 @@ TEST_SUITE("script::Compiler") {
     Variables variables{};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `target`: Undefined parameter.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Nested true statements will fail") {
     const std::string source{R"(echo %{a b 'Wrong' 'Hello' or 'Bye'})"};
     Location location{1, 1, R"(script = "echo %{target 'Hello' or 'Bye'}")"};
     Variables variables{
-        {"a", litr::cli::Variable("a", true)}, {"b", litr::cli::Variable("b", true)}};
+        {"a", Litr::CLI::Variable("a", true)}, {"b", Litr::CLI::Variable("b", true)}};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `'Hello'`: Expected `}`.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Nested false and true statements will fail") {
     const std::string source{R"(echo %{a b 'Wrong' 'Hello' or 'Bye'})"};
     Location location{1, 1, R"(script = "echo %{target 'Hello' or 'Bye'}")"};
     Variables variables{
-        {{"a", litr::cli::Variable("a", true)}, {"b", litr::cli::Variable("b", false)}}};
+        {{"a", Litr::CLI::Variable("a", true)}, {"b", Litr::CLI::Variable("b", false)}}};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `'Hello'`: Expected `}`.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Nested true and false statements will fail") {
     const std::string source{R"(echo %{a b 'Wrong' 'Hello' or 'Bye'})"};
     Location location{1, 1, R"(script = "echo %{target 'Hello' or 'Bye'}")"};
     Variables variables{
-        {{"a", litr::cli::Variable("a", false)}, {"b", litr::cli::Variable("b", true)}}};
+        {{"a", Litr::CLI::Variable("a", false)}, {"b", Litr::CLI::Variable("b", true)}}};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `'Wrong'`: Expected `}`.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Nested false statements will fail") {
     const std::string source{R"(echo %{a b 'Wrong' 'Hello' or 'Bye'})"};
     Location location{1, 1, R"(script = "echo %{target 'Hello' or 'Bye'}")"};
     Variables variables{
-        {{"a", litr::cli::Variable("a", false)}, {"b", litr::cli::Variable("b", false)}}};
+        {{"a", Litr::CLI::Variable("a", false)}, {"b", Litr::CLI::Variable("b", false)}}};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `'Wrong'`: Expected `}`.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Multiple strings in a row fail") {
@@ -211,55 +211,55 @@ TEST_SUITE("script::Compiler") {
     Variables variables{};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `' '`: Expected `}`.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Does throw on multiple non boolean variables in a row") {
     const std::string source{"echo '%{target value}'"};
     Location location{1, 1, R"(script = "echo '%{target value}'")"};
-    Variables variables{{{"target", litr::cli::Variable("target", std::string("Hello"))},
-        {"value", litr::cli::Variable("value", std::string(" World"))}}};
+    Variables variables{{{"target", Litr::CLI::Variable("target", std::string("Hello"))},
+        {"value", Litr::CLI::Variable("value", std::string(" World"))}}};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `value`: Expected `}`.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Fails on duplicated 'or' for true case") {
     const std::string source{"echo '%{target 'a' or or 'b'}'"};
     Location location{1, 1, R"(script = "echo '%{target 'a' or or 'b'}'")"};
-    Variables variables{{{"target", litr::cli::Variable("target", true)}}};
+    Variables variables{{{"target", Litr::CLI::Variable("target", true)}}};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `'b'`: Expected `}`.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Fails on duplicated 'or' for false case") {
     const std::string source{"echo '%{target 'a' or or 'b'}'"};
     Location location{1, 1, R"(script = "echo '%{target 'a' or or 'b'}'")"};
-    Variables variables{{{"target", litr::cli::Variable("target", false)}}};
+    Variables variables{{{"target", Litr::CLI::Variable("target", false)}}};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `'b'`: Expected `}`.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Failed on single or") {
@@ -268,12 +268,12 @@ TEST_SUITE("script::Compiler") {
     Variables variables{};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `or`: Unexpected character.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Failed on single comma") {
@@ -282,12 +282,12 @@ TEST_SUITE("script::Compiler") {
     Variables variables{};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `,`: Unexpected character.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 
   TEST_CASE("Failed on standalone parens") {
@@ -296,11 +296,11 @@ TEST_SUITE("script::Compiler") {
     Variables variables{};
     Compiler compiler{source, location, variables};
 
-    CHECK(litr::error::Handler::has_errors());
+    CHECK(Litr::Error::Handler::has_errors());
 
-    auto errors{litr::error::Handler::get_errors()};
+    auto errors{Litr::Error::Handler::get_errors()};
     CHECK_EQ(errors.size(), 1);
     CHECK_EQ(errors[0].message, "Cannot parse at `(`: Unexpected character.");
-    litr::error::Handler::flush();
+    Litr::Error::Handler::flush();
   }
 }

--- a/src/tests/Tests/Core/Script/Scanner.unit.cpp
+++ b/src/tests/Tests/Core/Script/Scanner.unit.cpp
@@ -15,86 +15,86 @@
 #define CHECK_DEFINITION(scanner, definition)                              \
   {                                                                        \
     for (auto&& test : (definition)) {                                     \
-      litr::script::Token token{(scanner).scan_token()};                   \
+      Litr::Script::Token token{(scanner).scan_token()};                   \
       CHECK_EQ(token.type, test.type);                                     \
-      CHECK_EQ(litr::script::Scanner::get_token_value(token), test.value); \
+      CHECK_EQ(Litr::Script::Scanner::get_token_value(token), test.value); \
     }                                                                      \
   }
 
 #define CHECK_EOS_TOKEN(scanner)                               \
   {                                                            \
-    litr::script::Token eos{(scanner).scan_token()};           \
-    CHECK_EQ(eos.type, litr::script::TokenType::EOS);          \
-    CHECK_EQ(litr::script::Scanner::get_token_value(eos), ""); \
+    Litr::Script::Token eos{(scanner).scan_token()};           \
+    CHECK_EQ(eos.type, Litr::Script::TokenType::EOS);          \
+    CHECK_EQ(Litr::Script::Scanner::get_token_value(eos), ""); \
   }
 
 struct TokenDefinition {
-  litr::script::TokenType type;
+  Litr::Script::TokenType type;
   std::string value;
 };
 
 TEST_SUITE("script::Scanner") {
   // Successful cases
   TEST_CASE("Nothing to parse") {
-    litr::script::Scanner scanner{"echo 'Hello World!'"};
+    Litr::Script::Scanner scanner{"echo 'Hello World!'"};
 
     std::array<TokenDefinition, 1> definition{
-        {{litr::script::TokenType::UNTOUCHED, "echo 'Hello World!'"}}};
+        {{Litr::Script::TokenType::UNTOUCHED, "echo 'Hello World!'"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Nothing to parse on escaped sequence") {
-    litr::script::Scanner scanner{R"(echo \%{something})"};
+    Litr::Script::Scanner scanner{R"(echo \%{something})"};
 
     std::array<TokenDefinition, 1> definition{
-        {{litr::script::TokenType::UNTOUCHED, R"(echo \%{something})"}}};
+        {{Litr::Script::TokenType::UNTOUCHED, R"(echo \%{something})"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Single variable") {
-    litr::script::Scanner scanner{"echo %{var}"};
+    Litr::Script::Scanner scanner{"echo %{var}"};
 
-    std::array<TokenDefinition, 4> definition{{{litr::script::TokenType::UNTOUCHED, "echo "},
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::IDENTIFIER, "var"},
-        {litr::script::TokenType::END_SEQ, "}"}}};
+    std::array<TokenDefinition, 4> definition{{{Litr::Script::TokenType::UNTOUCHED, "echo "},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::IDENTIFIER, "var"},
+        {Litr::Script::TokenType::END_SEQ, "}"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Ignores duplicated closing brace") {
-    litr::script::Scanner scanner{"echo %{var}}"};
+    Litr::Script::Scanner scanner{"echo %{var}}"};
 
     constexpr int item_count{5};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::script::TokenType::UNTOUCHED, "echo "},
-            {litr::script::TokenType::START_SEQ, "%{"},
-            {litr::script::TokenType::IDENTIFIER, "var"},
-            {litr::script::TokenType::END_SEQ, "}"},
-            {litr::script::TokenType::UNTOUCHED, "}"}}};
+        {{Litr::Script::TokenType::UNTOUCHED, "echo "},
+            {Litr::Script::TokenType::START_SEQ, "%{"},
+            {Litr::Script::TokenType::IDENTIFIER, "var"},
+            {Litr::Script::TokenType::END_SEQ, "}"},
+            {Litr::Script::TokenType::UNTOUCHED, "}"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Multiple variables") {
-    litr::script::Scanner scanner{"echo %{var1} and %{var2}"};
+    Litr::Script::Scanner scanner{"echo %{var1} and %{var2}"};
 
     constexpr int item_count{8};
     std::array<TokenDefinition, item_count> definition{{
-        {litr::script::TokenType::UNTOUCHED, "echo "},
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::IDENTIFIER, "var1"},
-        {litr::script::TokenType::END_SEQ, "}"},
-        {litr::script::TokenType::UNTOUCHED, " and "},
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::IDENTIFIER, "var2"},
-        {litr::script::TokenType::END_SEQ, "}"},
+        {Litr::Script::TokenType::UNTOUCHED, "echo "},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::IDENTIFIER, "var1"},
+        {Litr::Script::TokenType::END_SEQ, "}"},
+        {Litr::Script::TokenType::UNTOUCHED, " and "},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::IDENTIFIER, "var2"},
+        {Litr::Script::TokenType::END_SEQ, "}"},
     }};
 
     CHECK_DEFINITION(scanner, definition);
@@ -102,19 +102,19 @@ TEST_SUITE("script::Scanner") {
   }
 
   TEST_CASE("Multiple variables in between") {
-    litr::script::Scanner scanner{"echo %{var1} and %{var2} end"};
+    Litr::Script::Scanner scanner{"echo %{var1} and %{var2} end"};
 
     constexpr int item_count{9};
     std::array<TokenDefinition, item_count> definition{{
-        {litr::script::TokenType::UNTOUCHED, "echo "},
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::IDENTIFIER, "var1"},
-        {litr::script::TokenType::END_SEQ, "}"},
-        {litr::script::TokenType::UNTOUCHED, " and "},
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::IDENTIFIER, "var2"},
-        {litr::script::TokenType::END_SEQ, "}"},
-        {litr::script::TokenType::UNTOUCHED, " end"},
+        {Litr::Script::TokenType::UNTOUCHED, "echo "},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::IDENTIFIER, "var1"},
+        {Litr::Script::TokenType::END_SEQ, "}"},
+        {Litr::Script::TokenType::UNTOUCHED, " and "},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::IDENTIFIER, "var2"},
+        {Litr::Script::TokenType::END_SEQ, "}"},
+        {Litr::Script::TokenType::UNTOUCHED, " end"},
     }};
 
     CHECK_DEFINITION(scanner, definition);
@@ -122,56 +122,56 @@ TEST_SUITE("script::Scanner") {
   }
 
   TEST_CASE("Single string") {
-    litr::script::Scanner scanner{"echo %{'Hello'}"};
+    Litr::Script::Scanner scanner{"echo %{'Hello'}"};
 
-    std::array<TokenDefinition, 4> definition{{{litr::script::TokenType::UNTOUCHED, "echo "},
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::STRING, "'Hello'"},
-        {litr::script::TokenType::END_SEQ, "}"}}};
+    std::array<TokenDefinition, 4> definition{{{Litr::Script::TokenType::UNTOUCHED, "echo "},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::STRING, "'Hello'"},
+        {Litr::Script::TokenType::END_SEQ, "}"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Single string including ignored expression syntax") {
-    litr::script::Scanner scanner{"echo %{'He%{ll}o'}"};
+    Litr::Script::Scanner scanner{"echo %{'He%{ll}o'}"};
 
-    std::array<TokenDefinition, 4> definition{{{litr::script::TokenType::UNTOUCHED, "echo "},
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::STRING, "'He%{ll}o'"},
-        {litr::script::TokenType::END_SEQ, "}"}}};
+    std::array<TokenDefinition, 4> definition{{{Litr::Script::TokenType::UNTOUCHED, "echo "},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::STRING, "'He%{ll}o'"},
+        {Litr::Script::TokenType::END_SEQ, "}"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Single string with leading variable") {
-    litr::script::Scanner scanner{"echo %{var 'Hello'}"};
+    Litr::Script::Scanner scanner{"echo %{var 'Hello'}"};
 
     constexpr int item_count{5};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::script::TokenType::UNTOUCHED, "echo "},
-            {litr::script::TokenType::START_SEQ, "%{"},
-            {litr::script::TokenType::IDENTIFIER, "var"},
-            {litr::script::TokenType::STRING, "'Hello'"},
-            {litr::script::TokenType::END_SEQ, "}"}}};
+        {{Litr::Script::TokenType::UNTOUCHED, "echo "},
+            {Litr::Script::TokenType::START_SEQ, "%{"},
+            {Litr::Script::TokenType::IDENTIFIER, "var"},
+            {Litr::Script::TokenType::STRING, "'Hello'"},
+            {Litr::Script::TokenType::END_SEQ, "}"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Strings and or-statement") {
-    litr::script::Scanner scanner{"echo %{var 'Hello' or 'Bye'}"};
+    Litr::Script::Scanner scanner{"echo %{var 'Hello' or 'Bye'}"};
 
     constexpr int item_count{7};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::script::TokenType::UNTOUCHED, "echo "},
-            {litr::script::TokenType::START_SEQ, "%{"},
-            {litr::script::TokenType::IDENTIFIER, "var"},
-            {litr::script::TokenType::STRING, "'Hello'"},
-            {litr::script::TokenType::OR, "or"},
-            {litr::script::TokenType::STRING, "'Bye'"},
-            {litr::script::TokenType::END_SEQ, "}"}}};
+        {{Litr::Script::TokenType::UNTOUCHED, "echo "},
+            {Litr::Script::TokenType::START_SEQ, "%{"},
+            {Litr::Script::TokenType::IDENTIFIER, "var"},
+            {Litr::Script::TokenType::STRING, "'Hello'"},
+            {Litr::Script::TokenType::OR, "or"},
+            {Litr::Script::TokenType::STRING, "'Bye'"},
+            {Litr::Script::TokenType::END_SEQ, "}"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
@@ -179,17 +179,17 @@ TEST_SUITE("script::Scanner") {
 
   /*
   TEST_CASE("Strings and and-statement") {
-    litr::script::Scanner scanner{"echo %{var1 and var2 'Hello'}"};
+    Litr::Script::Scanner scanner{"echo %{var1 and var2 'Hello'}"};
 
     constexpr int item_count{7};
     std::array<TokenDefinition, item_count> definition{{
-        {litr::script::TokenType::UNTOUCHED, "echo "},
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::IDENTIFIER, "var1"},
-        {litr::script::TokenType::AND, "and"},
-        {litr::script::TokenType::IDENTIFIER, "var2"},
-        {litr::script::TokenType::STRING, "'Hello'"},
-        {litr::script::TokenType::END_SEQ, "}"}
+        {Litr::Script::TokenType::UNTOUCHED, "echo "},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::IDENTIFIER, "var1"},
+        {Litr::Script::TokenType::AND, "and"},
+        {Litr::Script::TokenType::IDENTIFIER, "var2"},
+        {Litr::Script::TokenType::STRING, "'Hello'"},
+        {Litr::Script::TokenType::END_SEQ, "}"}
     }};
 
     CHECK_DEFINITION(scanner, definition);
@@ -198,98 +198,98 @@ TEST_SUITE("script::Scanner") {
   */
 
   TEST_CASE("Function usage with single argument") {
-    litr::script::Scanner scanner{"echo %{case_camel(var)}"};
+    Litr::Script::Scanner scanner{"echo %{case_camel(var)}"};
 
     constexpr int item_count{7};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::script::TokenType::UNTOUCHED, "echo "},
-            {litr::script::TokenType::START_SEQ, "%{"},
-            {litr::script::TokenType::IDENTIFIER, "case_camel"},
-            {litr::script::TokenType::LEFT_PAREN, "("},
-            {litr::script::TokenType::IDENTIFIER, "var"},
-            {litr::script::TokenType::RIGHT_PAREN, ")"},
-            {litr::script::TokenType::END_SEQ, "}"}}};
+        {{Litr::Script::TokenType::UNTOUCHED, "echo "},
+            {Litr::Script::TokenType::START_SEQ, "%{"},
+            {Litr::Script::TokenType::IDENTIFIER, "case_camel"},
+            {Litr::Script::TokenType::LEFT_PAREN, "("},
+            {Litr::Script::TokenType::IDENTIFIER, "var"},
+            {Litr::Script::TokenType::RIGHT_PAREN, ")"},
+            {Litr::Script::TokenType::END_SEQ, "}"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Function usage with two arguments") {
-    litr::script::Scanner scanner{"echo %{case_camel(var1, var2)}"};
+    Litr::Script::Scanner scanner{"echo %{case_camel(var1, var2)}"};
 
     constexpr int item_count{9};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::script::TokenType::UNTOUCHED, "echo "},
-            {litr::script::TokenType::START_SEQ, "%{"},
-            {litr::script::TokenType::IDENTIFIER, "case_camel"},
-            {litr::script::TokenType::LEFT_PAREN, "("},
-            {litr::script::TokenType::IDENTIFIER, "var1"},
-            {litr::script::TokenType::COMMA, ","},
-            {litr::script::TokenType::IDENTIFIER, "var2"},
-            {litr::script::TokenType::RIGHT_PAREN, ")"},
-            {litr::script::TokenType::END_SEQ, "}"}}};
+        {{Litr::Script::TokenType::UNTOUCHED, "echo "},
+            {Litr::Script::TokenType::START_SEQ, "%{"},
+            {Litr::Script::TokenType::IDENTIFIER, "case_camel"},
+            {Litr::Script::TokenType::LEFT_PAREN, "("},
+            {Litr::Script::TokenType::IDENTIFIER, "var1"},
+            {Litr::Script::TokenType::COMMA, ","},
+            {Litr::Script::TokenType::IDENTIFIER, "var2"},
+            {Litr::Script::TokenType::RIGHT_PAREN, ")"},
+            {Litr::Script::TokenType::END_SEQ, "}"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Function usage with or-statement") {
-    litr::script::Scanner scanner{"echo %{fn(var) 'First' or 'Second'}"};
+    Litr::Script::Scanner scanner{"echo %{fn(var) 'First' or 'Second'}"};
 
     constexpr int item_count{10};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::script::TokenType::UNTOUCHED, "echo "},
-            {litr::script::TokenType::START_SEQ, "%{"},
-            {litr::script::TokenType::IDENTIFIER, "fn"},
-            {litr::script::TokenType::LEFT_PAREN, "("},
-            {litr::script::TokenType::IDENTIFIER, "var"},
-            {litr::script::TokenType::RIGHT_PAREN, ")"},
-            {litr::script::TokenType::STRING, "'First'"},
-            {litr::script::TokenType::OR, "or"},
-            {litr::script::TokenType::STRING, "'Second'"},
-            {litr::script::TokenType::END_SEQ, "}"}}};
+        {{Litr::Script::TokenType::UNTOUCHED, "echo "},
+            {Litr::Script::TokenType::START_SEQ, "%{"},
+            {Litr::Script::TokenType::IDENTIFIER, "fn"},
+            {Litr::Script::TokenType::LEFT_PAREN, "("},
+            {Litr::Script::TokenType::IDENTIFIER, "var"},
+            {Litr::Script::TokenType::RIGHT_PAREN, ")"},
+            {Litr::Script::TokenType::STRING, "'First'"},
+            {Litr::Script::TokenType::OR, "or"},
+            {Litr::Script::TokenType::STRING, "'Second'"},
+            {Litr::Script::TokenType::END_SEQ, "}"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Nested function usage") {
-    litr::script::Scanner scanner{"echo %{fn1(fn2(var1), var2)}"};
+    Litr::Script::Scanner scanner{"echo %{fn1(fn2(var1), var2)}"};
 
     constexpr int item_count{12};
     std::array<TokenDefinition, item_count> definition{
-        {{litr::script::TokenType::UNTOUCHED, "echo "},
-            {litr::script::TokenType::START_SEQ, "%{"},
-            {litr::script::TokenType::IDENTIFIER, "fn1"},
-            {litr::script::TokenType::LEFT_PAREN, "("},
-            {litr::script::TokenType::IDENTIFIER, "fn2"},
-            {litr::script::TokenType::LEFT_PAREN, "("},
-            {litr::script::TokenType::IDENTIFIER, "var1"},
-            {litr::script::TokenType::RIGHT_PAREN, ")"},
-            {litr::script::TokenType::COMMA, ","},
-            {litr::script::TokenType::IDENTIFIER, "var2"},
-            {litr::script::TokenType::RIGHT_PAREN, ")"},
-            {litr::script::TokenType::END_SEQ, "}"}}};
+        {{Litr::Script::TokenType::UNTOUCHED, "echo "},
+            {Litr::Script::TokenType::START_SEQ, "%{"},
+            {Litr::Script::TokenType::IDENTIFIER, "fn1"},
+            {Litr::Script::TokenType::LEFT_PAREN, "("},
+            {Litr::Script::TokenType::IDENTIFIER, "fn2"},
+            {Litr::Script::TokenType::LEFT_PAREN, "("},
+            {Litr::Script::TokenType::IDENTIFIER, "var1"},
+            {Litr::Script::TokenType::RIGHT_PAREN, ")"},
+            {Litr::Script::TokenType::COMMA, ","},
+            {Litr::Script::TokenType::IDENTIFIER, "var2"},
+            {Litr::Script::TokenType::RIGHT_PAREN, ")"},
+            {Litr::Script::TokenType::END_SEQ, "}"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Does not care about invalid semantic") {
-    litr::script::Scanner scanner{"echo %{var"};
+    Litr::Script::Scanner scanner{"echo %{var"};
 
-    std::array<TokenDefinition, 3> definition{{{litr::script::TokenType::UNTOUCHED, "echo "},
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::IDENTIFIER, "var"}}};
+    std::array<TokenDefinition, 3> definition{{{Litr::Script::TokenType::UNTOUCHED, "echo "},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::IDENTIFIER, "var"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Ignores percentage sign without opening brace") {
-    litr::script::Scanner scanner{"echo %var"};
+    Litr::Script::Scanner scanner{"echo %var"};
 
-    std::array<TokenDefinition, 1> definition{{{litr::script::TokenType::UNTOUCHED, "echo %var"}}};
+    std::array<TokenDefinition, 1> definition{{{Litr::Script::TokenType::UNTOUCHED, "echo %var"}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
@@ -297,24 +297,24 @@ TEST_SUITE("script::Scanner") {
 
   // Error cases
   TEST_CASE("Unterminated string") {
-    litr::script::Scanner scanner{"echo %{'Hello}"};
+    Litr::Script::Scanner scanner{"echo %{'Hello}"};
 
-    std::array<TokenDefinition, 3> definition{{{litr::script::TokenType::UNTOUCHED, "echo "},
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::ERROR, "Unterminated string."}}};
+    std::array<TokenDefinition, 3> definition{{{Litr::Script::TokenType::UNTOUCHED, "echo "},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::ERROR, "Unterminated string."}}};
 
     CHECK_DEFINITION(scanner, definition);
     CHECK_EOS_TOKEN(scanner);
   }
 
   TEST_CASE("Invalidates unknown characters, but does not stop scanning") {
-    litr::script::Scanner scanner{"%{? fn}"};
+    Litr::Script::Scanner scanner{"%{? fn}"};
 
     std::array<TokenDefinition, 4> definition{{
-        {litr::script::TokenType::START_SEQ, "%{"},
-        {litr::script::TokenType::ERROR, "Unexpected character."},
-        {litr::script::TokenType::IDENTIFIER, "fn"},
-        {litr::script::TokenType::END_SEQ, "}"},
+        {Litr::Script::TokenType::START_SEQ, "%{"},
+        {Litr::Script::TokenType::ERROR, "Unexpected character."},
+        {Litr::Script::TokenType::IDENTIFIER, "fn"},
+        {Litr::Script::TokenType::END_SEQ, "}"},
     }};
 
     CHECK_DEFINITION(scanner, definition);

--- a/src/tests/Tests/Core/Utils.unit.cpp
+++ b/src/tests/Tests/Core/Utils.unit.cpp
@@ -13,27 +13,27 @@
 TEST_SUITE("Utils") {
   TEST_CASE("trim_left") {
     SUBCASE("Does trim only left side of string") {
-      CHECK_EQ(litr::utils::trim_left("  Bob  ", ' '), "Bob  ");
+      CHECK_EQ(Litr::Utils::trim_left("  Bob  ", ' '), "Bob  ");
     }
 
     SUBCASE("Trims nothing if nothing found") {
-      CHECK_EQ(litr::utils::trim_left("..Bob..", ' '), "..Bob..");
+      CHECK_EQ(Litr::Utils::trim_left("..Bob..", ' '), "..Bob..");
     }
   }
 
   TEST_CASE("trim_right") {
     SUBCASE("Does trim only right side of string") {
-      CHECK_EQ(litr::utils::trim_right("  Bob  ", ' '), "  Bob");
+      CHECK_EQ(Litr::Utils::trim_right("  Bob  ", ' '), "  Bob");
     }
 
     SUBCASE("Trims nothing if nothing found") {
-      CHECK_EQ(litr::utils::trim_right("..Bob..", ' '), "..Bob..");
+      CHECK_EQ(Litr::Utils::trim_right("..Bob..", ' '), "..Bob..");
     }
   }
 
   TEST_CASE("trim") {
     SUBCASE("Trims both sides of string") {
-      CHECK_EQ(litr::utils::trim("....Bob..", '.'), "Bob");
+      CHECK_EQ(Litr::Utils::trim("....Bob..", '.'), "Bob");
     }
   }
 
@@ -41,28 +41,28 @@ TEST_SUITE("Utils") {
     SUBCASE("Multiple items into vector") {
       const std::string input{"This\nIs\nA\nTest"};
       std::vector<std::string> output{};
-      litr::utils::split_into(input, '\n', output);
+      Litr::Utils::split_into(input, '\n', output);
       CHECK_EQ(output.size(), 4);
     }
 
     SUBCASE("One item into vector") {
       const std::string input{"This Is A Test"};
       std::vector<std::string> output{};
-      litr::utils::split_into(input, '\n', output);
+      Litr::Utils::split_into(input, '\n', output);
       CHECK_EQ(output.size(), 1);
     }
 
     SUBCASE("Multiple items into deque") {
       const std::string input{"path.to.somewhere"};
       std::deque<std::string> output{};
-      litr::utils::split_into(input, '.', output);
+      Litr::Utils::split_into(input, '.', output);
       CHECK_EQ(output.size(), 3);
     }
 
     SUBCASE("One item into deque") {
       const std::string input{"path.to.somewhere"};
       std::deque<std::string> output{};
-      litr::utils::split_into(input, ' ', output);
+      Litr::Utils::split_into(input, ' ', output);
       CHECK_EQ(output.size(), 1);
     }
   }
@@ -70,13 +70,13 @@ TEST_SUITE("Utils") {
   TEST_CASE("deduplicate") {
     SUBCASE("Removes duplicates") {
       std::vector<std::string> items{{"Cobra", "Python", "DBX", "Python", "DBX", "DBX", "Clipper"}};
-      litr::utils::deduplicate(items);
+      Litr::Utils::deduplicate(items);
       CHECK_EQ(items.size(), 4);
     }
 
     SUBCASE("Does nothing if no duplicates found") {
       std::vector<std::string> items{{"Cobra", "Python", "DBX", "Clipper"}};
-      litr::utils::deduplicate(items);
+      Litr::Utils::deduplicate(items);
       CHECK_EQ(items.size(), 4);
     }
   }
@@ -86,14 +86,14 @@ TEST_SUITE("Utils") {
       const std::string source{"This is an example"};
       const std::string from{"is an"};
       const std::string to{"is not an"};
-      CHECK_EQ(litr::utils::replace(source, from, to), "This is not an example");
+      CHECK_EQ(Litr::Utils::replace(source, from, to), "This is not an example");
     }
 
     SUBCASE("Replaces nothing if nothing found") {
       const std::string source{"This is an example"};
       const std::string from{"Rand"};
       const std::string to{"Perrin"};
-      CHECK_EQ(litr::utils::replace(source, from, to), "This is an example");
+      CHECK_EQ(Litr::Utils::replace(source, from, to), "This is an example");
     }
   }
 }


### PR DESCRIPTION
So far commands and parameters read from the TOML configuration file were ordered alphabetically instead of in order of definition. This is now fixed and commands and parameters are read and processed in order of definition. This also means that they will now appear in order when calling `litr --help`.

Closes #65