### PR TITLE
Show description for specific command help

### DIFF
--- a/src/client/Client/Hooks/Help.cpp
+++ b/src/client/Client/Hooks/Help.cpp
@@ -48,13 +48,24 @@ void Help::print_usage() const {
   LITR_PROFILE_FUNCTION();
 
   if (!m_command_name.empty()) {
-    std::string command_name{m_command_name};
-    std::replace(command_name.begin(), command_name.end(), '.', ' ');
-    fmt::print("Usage: litr {} [options]\n\n", command_name);
+    print_command_usage();
     return;
   }
 
   fmt::print("Usage: litr command [options]\n\n");
+}
+
+void Help::print_command_usage() const {
+  std::string command_name{m_command_name};
+  std::replace(command_name.begin(), command_name.end(), '.', ' ');
+  fmt::print("Usage: litr {} [options]", command_name);
+
+  const std::string description{m_query.get_command(m_command_name)->description};
+  if (!description.empty()) {
+    fmt::print("\n  {}", m_query.get_command(m_command_name)->description);
+  }
+
+  fmt::print("\n\n");
 }
 
 void Help::print_commands() const {

--- a/src/client/Client/Hooks/Help.hpp
+++ b/src/client/Client/Hooks/Help.hpp
@@ -19,10 +19,13 @@ class Help {
  private:
   void print_welcome_message() const;
   void print_usage() const;
+  void print_command_usage() const;
+
   void print_commands() const;
   void print_command(const std::shared_ptr<Config::Command>& command,
       const std::string& parent_name,
       size_t depth = 1) const;
+
   void print_example(const std::shared_ptr<Config::Command>& command) const;
   void print_options() const;
   void print_parameter_options(const std::shared_ptr<Config::Parameter>& param) const;

--- a/src/core/Core/Config/FileAdapter.hpp
+++ b/src/core/Core/Config/FileAdapter.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <tsl/ordered_map.h>
-
 #include <string>
 
 #include "Core/FileSystem.hpp"
@@ -16,7 +14,6 @@ template <typename T>
 class FileAdapter {
  public:
   using Value = T;
-  using Table = tsl::ordered_map<std::string, Value>;
 
   virtual ~FileAdapter() = default;
 


### PR DESCRIPTION
Running help for a specific command will now show the description for that command underneath the usage.

Closes #57